### PR TITLE
Improving the computation of Alpha's

### DIFF
--- a/types/+equMPC/code_equMPC_ADMM_C.c
+++ b/types/+equMPC/code_equMPC_ADMM_C.c
@@ -67,9 +67,8 @@ void equMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
         double Q_rho_i[nn_] = {0.0}; // 1./(Q+rho*I)
         double AQiAt[nn_][nn_] = {{0.0}}; // A*inv(Q+rho*I)*A'
         double BRiBt[nn_][nn_] = {{0.0}}; // B*inv(R+rho*I)*B'
-        double Alpha[NN_-1][nn_][nn_] = {{{0.0}}};
-        double Beta[NN_][nn_][nn_] = {{{0.0}}};
-        double inv_Beta_diag[NN_][nn_] = {{0.0}};
+        double Alpha[NN_-1][nn_][nn_] = {{{0.0}}}; // Variables used for solving the equality constrained QP
+        double Beta[NN_][nn_][nn_] = {{{0.0}}}; // Variables used for solving the equality constrained QP. Note: Diagonal of Beta's are inverted
         double LB[nm_]; // Lower bound for box constraints 
         double UB[nm_]; // Upper bound for box constraints
     #endif
@@ -184,12 +183,11 @@ void equMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
                 }     
             }
             if (i==j){
-                Beta[0][i][j] += Q_rho_i[i];
-                Beta[0][i][j] = sqrt(Beta[0][i][j]);
-                inv_Beta_diag[0][i] = 1/Beta[0][i][i];
+                Beta[0][i][i] += Q_rho_i[i];
+                Beta[0][i][i] = 1/sqrt(Beta[0][i][i]);
             }
             else{
-                Beta[0][i][j] = Beta[0][i][j]*inv_Beta_diag[0][i];
+                Beta[0][i][j] = Beta[0][i][j]*Beta[0][i][i];
             }
         }
     }
@@ -206,7 +204,7 @@ void equMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
                 }
             }
 
-            Alpha[0][i][j] = Alpha[0][i][j]*inv_Beta_diag[0][i];
+            Alpha[0][i][j] = Alpha[0][i][j]*Beta[0][i][i];
 
         }
     }
@@ -229,12 +227,11 @@ void equMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
                 }
                     
                 if(i==j){
-                    Beta[h][i][j] += Q_rho_i[i];   
-                    Beta[h][i][j] = sqrt(Beta[h][i][j]);
-                    inv_Beta_diag[h][i] = 1/Beta[h][i][i];
+                    Beta[h][i][i] += Q_rho_i[i];   
+                    Beta[h][i][i] = 1/sqrt(Beta[h][i][i]);
                 }
                 else {
-                    Beta[h][i][j] = Beta[h][i][j]*inv_Beta_diag[h][i];
+                    Beta[h][i][j] = Beta[h][i][j]*Beta[h][i][i];
                 }
             }
         }
@@ -251,7 +248,7 @@ void equMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
                     }
                 }
 
-                Alpha[h][i][j] = Alpha[h][i][j]*inv_Beta_diag[h][i];
+                Alpha[h][i][j] = Alpha[h][i][j]*Beta[h][i][i];
 
             }
         }
@@ -275,24 +272,14 @@ void equMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
             }
 
             if(i==j){
-                Beta[NN_-1][i][j] = sqrt(Beta[NN_-1][i][j]);
-                inv_Beta_diag[NN_-1][i] = 1/Beta[NN_-1][i][i];
+                Beta[NN_-1][i][i] = 1/sqrt(Beta[NN_-1][i][i]);
             }
 
             else{
-                Beta[NN_-1][i][j] = Beta[NN_-1][i][j]*inv_Beta_diag[NN_-1][i];
+                Beta[NN_-1][i][j] = Beta[NN_-1][i][j]*Beta[NN_-1][i][i];
             }
         }
     }    
-
-    for (unsigned int h=0 ; h<NN_ ; h++){
-
-        for (unsigned int i=0 ; i<nn_ ; i++){
-            Beta[h][i][i] = inv_Beta_diag[h][i]; // We need to make the component-wise inversion of the diagonal elements of Beta's
-        }
-        
-    }
-
     // End of computation of Alpha and Beta
 
     // Multiply Q and R by -1, since this value is used the rest of the algorithm

--- a/types/+equMPC/code_equMPC_ADMM_C.c
+++ b/types/+equMPC/code_equMPC_ADMM_C.c
@@ -69,7 +69,7 @@ void equMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
         double BRiBt[nn_][nn_] = {{0.0}}; // B*inv(R+rho*I)*B'
         double Alpha[NN_-1][nn_][nn_] = {{{0.0}}};
         double Beta[NN_][nn_][nn_] = {{{0.0}}};
-        double inv_Beta[nn_][nn_] = {{0.0}}; // Inverse of only the current beta is stored
+        double inv_Beta_diag[NN_][nn_] = {{0.0}};
         double LB[nm_]; // Lower bound for box constraints 
         double UB[nm_]; // Upper bound for box constraints
     #endif
@@ -186,34 +186,28 @@ void equMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
             if (i==j){
                 Beta[0][i][j] += Q_rho_i[i];
                 Beta[0][i][j] = sqrt(Beta[0][i][j]);
+                inv_Beta_diag[0][i] = 1/Beta[0][i][i];
             }
             else{
-                Beta[0][i][j] = Beta[0][i][j]/Beta[0][i][i];
+                Beta[0][i][j] = Beta[0][i][j]*inv_Beta_diag[0][i];
             }
         }
     }
 
-    // Inverse of Beta{0}
-    for (int i=nn_-1 ; i>=0 ; i--){
-        for (unsigned int j=0 ; j<nn_ ; j++){
-            if(i==j){
-                inv_Beta[i][i] = 1/Beta[0][i][i]; // Calculation of diagonal elements
-            }
-            else if (j>i){
-                for(unsigned int k = i+1 ; k<=j ; k++){
-                    inv_Beta[i][j] += Beta[0][i][k]*inv_Beta[k][j];
-            }
-                inv_Beta[i][j] = -1/Beta[0][i][i]*inv_Beta[i][j];
-            }
-        }
-    }
+    // ALpha{0}
+    for(unsigned int i=0 ; i < nn_ ; i++){
+        for(unsigned int j=0 ; j < nn_ ; j++){
 
-    // Alpha{0}
-    for (unsigned int i=0 ; i<nn_ ; i++){
-        for (unsigned int j=0 ; j<nn_ ; j++){
-            for (unsigned int k=0 ; k<=i ; k++){
-                Alpha[0][i][j] -= inv_Beta[k][i] * A_in[j+k*nn_] * Q_rho_i[k];
+            Alpha[0][i][j] = -Q_rho_i[i]*AB[j][i];
+            
+            if(i>0){
+                for(unsigned int l=0 ; l <= i-1 ; l++){
+                    Alpha[0][i][j] -= Beta[0][l][i] * Alpha[0][l][j];
+                }
             }
+
+            Alpha[0][i][j] = Alpha[0][i][j]*inv_Beta_diag[0][i];
+
         }
     }
 
@@ -221,6 +215,7 @@ void equMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
     for(unsigned int h = 1; h < NN_-1 ; h++){
         for(unsigned int i = 0 ; i < nn_ ; i++){
             for(unsigned int j = i ; j < nn_ ; j++){
+
                 Beta[h][i][j] = AQiAt[i][j] + BRiBt[i][j];
 
                 for(unsigned int k = 0 ; k < nn_ ; k++){
@@ -236,36 +231,28 @@ void equMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
                 if(i==j){
                     Beta[h][i][j] += Q_rho_i[i];   
                     Beta[h][i][j] = sqrt(Beta[h][i][j]);
+                    inv_Beta_diag[h][i] = 1/Beta[h][i][i];
                 }
                 else {
-                    Beta[h][i][j] = Beta[h][i][j]/Beta[h][i][i];
+                    Beta[h][i][j] = Beta[h][i][j]*inv_Beta_diag[h][i];
                 }
             }
         }
 
-        // Calculation of the inverse of the current Beta, needed for current Alpha
-        memset(inv_Beta, 0, sizeof(inv_Beta)); // Reset of inv_Beta when a new Beta is calculated
+        //Alpha[h][][]
+        for(unsigned int i=0 ; i < nn_ ; i++){
+            for(unsigned int j=0 ; j < nn_ ; j++){
 
-        for (int i=nn_-1 ; i>=0 ; i--){
-            for (unsigned int j=0 ; j<nn_ ; j++){
-                if(i==j){
-                    inv_Beta[i][i] = 1/Beta[h][i][i]; // Calculation of diagonal elements
-                }
-                else if (j>i){
-                    for(unsigned int k = i+1 ; k<=j ; k++){
-                        inv_Beta[i][j] += Beta[h][i][k]*inv_Beta[k][j];
+                Alpha[h][i][j] = -Q_rho_i[i]*AB[j][i];
+                
+                if(i>0){
+                    for(unsigned int l=0 ; l <= i-1 ; l++){
+                        Alpha[h][i][j] -= Beta[h][l][i] * Alpha[h][l][j];
                     }
-                    inv_Beta[i][j] = -1/Beta[h][i][i]*inv_Beta[i][j];
                 }
-            }
-        }
 
-        // Calculation of current Alpha
-        for (unsigned int i=0 ; i<nn_ ; i++){
-            for (unsigned int j=0 ; j<nn_ ; j++){
-                for (unsigned int k=0 ; k<=i ; k++){
-                    Alpha[h][i][j] -= inv_Beta[k][i] * A_in[j+k*nn_] * Q_rho_i[k];
-                }
+                Alpha[h][i][j] = Alpha[h][i][j]*inv_Beta_diag[h][i];
+
             }
         }
 
@@ -274,6 +261,7 @@ void equMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
     //Beta{N-1}
     for(unsigned int i = 0 ; i < nn_ ; i++){
         for(unsigned int j = i ; j < nn_ ; j++){
+
             Beta[NN_-1][i][j] = AQiAt[i][j] + BRiBt[i][j];
 
             for(unsigned int k=0 ; k<nn_ ; k++){
@@ -288,10 +276,11 @@ void equMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
 
             if(i==j){
                 Beta[NN_-1][i][j] = sqrt(Beta[NN_-1][i][j]);
+                inv_Beta_diag[NN_-1][i] = 1/Beta[NN_-1][i][i];
             }
 
             else{
-                Beta[NN_-1][i][j] = Beta[NN_-1][i][j]/Beta[NN_-1][i][i];
+                Beta[NN_-1][i][j] = Beta[NN_-1][i][j]*inv_Beta_diag[NN_-1][i];
             }
         }
     }    
@@ -299,7 +288,7 @@ void equMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
     for (unsigned int h=0 ; h<NN_ ; h++){
 
         for (unsigned int i=0 ; i<nn_ ; i++){
-            Beta[h][i][i] = 1/Beta[h][i][i]; // We need to make the component-wise inversion of the diagonal elements of Beta's
+            Beta[h][i][i] = inv_Beta_diag[h][i]; // We need to make the component-wise inversion of the diagonal elements of Beta's
         }
         
     }

--- a/types/+equMPC/code_equMPC_ADMM_C.c
+++ b/types/+equMPC/code_equMPC_ADMM_C.c
@@ -177,11 +177,10 @@ void equMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
 
             Beta[0][i][j] = BRiBt[i][j];
             
-            if(i>0){
-                for(unsigned int l = 0 ; l <= i-1 ; l++){
-                    Beta[0][i][j] -= Beta[0][l][i]*Beta[0][l][j];
-                }     
+            for(unsigned int l = 1 ; l <= i ; l++){
+                Beta[0][i][j] -= Beta[0][l-1][i]*Beta[0][l-1][j];
             }
+
             if (i==j){
                 Beta[0][i][i] += Q_rho_i[i];
                 Beta[0][i][i] = 1/sqrt(Beta[0][i][i]);
@@ -198,10 +197,8 @@ void equMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
 
             Alpha[0][i][j] = -Q_rho_i[i]*AB[j][i];
             
-            if(i>0){
-                for(unsigned int l=0 ; l <= i-1 ; l++){
-                    Alpha[0][i][j] -= Beta[0][l][i] * Alpha[0][l][j];
-                }
+            for(unsigned int l=1 ; l <= i ; l++){
+                Alpha[0][i][j] -= Beta[0][l-1][i] * Alpha[0][l-1][j];
             }
 
             Alpha[0][i][j] = Alpha[0][i][j]*Beta[0][i][i];
@@ -220,10 +217,8 @@ void equMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
                     Beta[h][i][j] -= Alpha[h-1][k][i]*Alpha[h-1][k][j];
                 }
                         
-                if(i>0){
-                    for(unsigned int l = 0 ; l<=i-1 ; l++){
-                        Beta[h][i][j] -= Beta[h][l][i]*Beta[h][l][j];
-                    }
+                for(unsigned int l = 1 ; l<=i ; l++){
+                    Beta[h][i][j] -= Beta[h][l-1][i]*Beta[h][l-1][j];
                 }
                     
                 if(i==j){
@@ -242,10 +237,8 @@ void equMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
 
                 Alpha[h][i][j] = -Q_rho_i[i]*AB[j][i];
                 
-                if(i>0){
-                    for(unsigned int l=0 ; l <= i-1 ; l++){
-                        Alpha[h][i][j] -= Beta[h][l][i] * Alpha[h][l][j];
-                    }
+                for(unsigned int l=1 ; l <= i ; l++){
+                    Alpha[h][i][j] -= Beta[h][l-1][i] * Alpha[h][l-1][j];
                 }
 
                 Alpha[h][i][j] = Alpha[h][i][j]*Beta[h][i][i];
@@ -265,10 +258,8 @@ void equMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
                 Beta[NN_-1][i][j] -= Alpha[NN_-2][k][i] * Alpha[NN_-2][k][j];
             }
 
-            if(i>0){
-                for(unsigned int l=0 ; l<=i-1 ; l++){
-                    Beta[NN_-1][i][j] -= Beta[NN_-1][l][i] * Beta[NN_-1][l][j];
-                }
+            for(unsigned int l=1 ; l<=i ; l++){
+                Beta[NN_-1][i][j] -= Beta[NN_-1][l-1][i] * Beta[NN_-1][l-1][j];
             }
 
             if(i==j){

--- a/types/+equMPC/code_equMPC_FISTA_C.c
+++ b/types/+equMPC/code_equMPC_FISTA_C.c
@@ -177,11 +177,10 @@ void equMPC_FISTA(double *x0_in, double *xr_in, double *ur_in, double *u_opt, in
 
             Beta[0][i][j] = BRiBt[i][j];
                 
-            if(i>0){
-                for(unsigned int l = 0 ; l <= i-1 ; l++){
-                    Beta[0][i][j] -= Beta[0][l][i]*Beta[0][l][j];
-                }               
-            }
+            for(unsigned int l = 1 ; l <= i ; l++){
+                Beta[0][i][j] -= Beta[0][l-1][i]*Beta[0][l-1][j];
+            }               
+
             if (i==j){
                 Beta[0][i][i] += Q_i[i];
                 Beta[0][i][i] = 1/sqrt(Beta[0][i][i]);
@@ -198,10 +197,8 @@ void equMPC_FISTA(double *x0_in, double *xr_in, double *ur_in, double *u_opt, in
 
             Alpha[0][i][j] = -Q_i[i]*AB[j][i];
             
-            if(i>0){
-                for(unsigned int l=0 ; l <= i-1 ; l++){
-                    Alpha[0][i][j] -= Beta[0][l][i] * Alpha[0][l][j];
-                }
+            for(unsigned int l=1 ; l <= i ; l++){
+                Alpha[0][i][j] -= Beta[0][l-1][i] * Alpha[0][l-1][j];
             }
 
             Alpha[0][i][j] = Alpha[0][i][j]*Beta[0][i][i];
@@ -220,10 +217,8 @@ void equMPC_FISTA(double *x0_in, double *xr_in, double *ur_in, double *u_opt, in
                     Beta[h][i][j] -= Alpha[h-1][k][i]*Alpha[h-1][k][j];
                 }
 
-                if(i>0){
-                    for(unsigned int l = 0 ; l<=i-1 ; l++){
-                        Beta[h][i][j] -= Beta[h][l][i]*Beta[h][l][j];
-                    }
+                for(unsigned int l = 1 ; l<=i ; l++){
+                    Beta[h][i][j] -= Beta[h][l-1][i]*Beta[h][l-1][j];
                 }
 
                 if(i==j){
@@ -244,10 +239,8 @@ void equMPC_FISTA(double *x0_in, double *xr_in, double *ur_in, double *u_opt, in
 
                 Alpha[h][i][j] = -Q_i[i]*AB[j][i];
                 
-                if(i>0){
-                    for(unsigned int l=0 ; l <= i-1 ; l++){
-                        Alpha[h][i][j] -= Beta[h][l][i] * Alpha[h][l][j];
-                    }
+                for(unsigned int l=1 ; l <= i ; l++){
+                    Alpha[h][i][j] -= Beta[h][l-1][i] * Alpha[h][l-1][j];
                 }
 
                 Alpha[h][i][j] = Alpha[h][i][j]*Beta[h][i][i];
@@ -265,12 +258,11 @@ void equMPC_FISTA(double *x0_in, double *xr_in, double *ur_in, double *u_opt, in
             for(unsigned int k=0 ; k<nn_ ; k++){
                 Beta[NN_-1][i][j] -= Alpha[NN_-2][k][i]*Alpha[NN_-2][k][j];
             }
-
-            if(i>0){
-                for(unsigned int l=0 ; l<=i-1 ; l++){
-                    Beta[NN_-1][i][j] -= Beta[NN_-1][l][i] * Beta[NN_-1][l][j];
-                }
+ 
+            for(unsigned int l=1 ; l<=i ; l++){
+                Beta[NN_-1][i][j] -= Beta[NN_-1][l-1][i] * Beta[NN_-1][l-1][j];
             }
+
             if(i==j){
                 Beta[NN_-1][i][i] = 1/sqrt(Beta[NN_-1][i][i]);
             }

--- a/types/+laxMPC/code_laxMPC_ADMM_C.c
+++ b/types/+laxMPC/code_laxMPC_ADMM_C.c
@@ -205,6 +205,7 @@ void laxMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
     // ALpha{0}
     for(unsigned int i=0 ; i < nn_ ; i++){
         for(unsigned int j=0 ; j < nn_ ; j++){
+
             Alpha[0][i][j] = -Q_rho_i[i]*AB[j][i];
             
             if(i>0){
@@ -248,8 +249,10 @@ void laxMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
             }
         }
         
+        //Alpha[h][][]
         for(unsigned int i=0 ; i < nn_ ; i++){
             for(unsigned int j=0 ; j < nn_ ; j++){
+
                 Alpha[h][i][j] = -Q_rho_i[i]*AB[j][i];
                 
                 if(i>0){

--- a/types/+laxMPC/code_laxMPC_ADMM_C.c
+++ b/types/+laxMPC/code_laxMPC_ADMM_C.c
@@ -69,7 +69,7 @@ void laxMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
         double AQiAt[nn_][nn_] = {{0.0}}; // A*inv(Q+rho*I)*A'
         double BRiBt[nn_][nn_] = {{0.0}}; // B*inv(R+rho*I)*B'
         double Alpha[NN_-1][nn_][nn_] = {{{0.0}}}; // Variables used for solving the equality constrained QP
-        double Beta[NN_][nn_][nn_] = {{{0.0}}}; // Variables used for solving the equality constrained QP
+        double Beta[NN_][nn_][nn_] = {{{0.0}}}; // Variables used for solving the equality constrained QP. Note: Diagonal of Beta's are inverted
         double LB[nm_]; // Lower bound for box constraints 
         double UB[nm_]; // Upper bound for box constraints
     #endif

--- a/types/+laxMPC/code_laxMPC_ADMM_C.c
+++ b/types/+laxMPC/code_laxMPC_ADMM_C.c
@@ -70,7 +70,6 @@ void laxMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
         double BRiBt[nn_][nn_] = {{0.0}}; // B*inv(R+rho*I)*B'
         double Alpha[NN_-1][nn_][nn_] = {{{0.0}}}; // Variables used for solving the equality constrained QP
         double Beta[NN_][nn_][nn_] = {{{0.0}}}; // Variables used for solving the equality constrained QP
-        double inv_Beta_diag[NN_][nn_] = {{0.0}}; // Diagonal elements of every Beta
         double LB[nm_]; // Lower bound for box constraints 
         double UB[nm_]; // Upper bound for box constraints
     #endif
@@ -192,12 +191,11 @@ void laxMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
                 }               
             }
             if (i==j){
-                Beta[0][i][j] += Q_rho_i[i];
-                Beta[0][i][j] = sqrt(Beta[0][i][j]);
-                inv_Beta_diag[0][i] = 1/Beta[0][i][i];
+                Beta[0][i][i] += Q_rho_i[i];
+                Beta[0][i][i] = 1/sqrt(Beta[0][i][i]);
             }
             else{ 
-                Beta[0][i][j] = Beta[0][i][j]*inv_Beta_diag[0][i];
+                Beta[0][i][j] = Beta[0][i][j]*Beta[0][i][i];
             }
         }
     }
@@ -214,7 +212,7 @@ void laxMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
                 }
             }
 
-            Alpha[0][i][j] = Alpha[0][i][j]*inv_Beta_diag[0][i];
+            Alpha[0][i][j] = Alpha[0][i][j]*Beta[0][i][i];
 
         }
     }
@@ -238,12 +236,11 @@ void laxMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
                 }
                     
                 if(i==j){
-                    Beta[h][i][j] += Q_rho_i[i];   
-                    Beta[h][i][j] = sqrt(Beta[h][i][j]);
-                    inv_Beta_diag[h][i] = 1/Beta[h][i][i];
+                    Beta[h][i][i] += Q_rho_i[i];   
+                    Beta[h][i][i] = 1/sqrt(Beta[h][i][i]);
                 }
                 else {
-                    Beta[h][i][j] = Beta[h][i][j]*inv_Beta_diag[h][i];
+                    Beta[h][i][j] = Beta[h][i][j]*Beta[h][i][i];
                 }
             
             }
@@ -261,7 +258,7 @@ void laxMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
                     }
                 }
 
-                Alpha[h][i][j] = Alpha[h][i][j]*inv_Beta_diag[h][i];
+                Alpha[h][i][j] = Alpha[h][i][j]*Beta[h][i][i];
 
             }
         }
@@ -288,23 +285,14 @@ void laxMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
             Beta[NN_-1][i][j] += T_rho_i[i][j]; // When calculating Beta{N}, as T_rho_i is dense, we add it in every component instead of only in the diagonal as in Beta{0} to Beta{N-2}
 
             if(i==j){    
-                Beta[NN_-1][i][j] = sqrt(Beta[NN_-1][i][j]);
-                inv_Beta_diag[NN_-1][i] = 1/Beta[NN_-1][i][i];
+                Beta[NN_-1][i][i] = 1/sqrt(Beta[NN_-1][i][i]);
             }
 
             else{
-                Beta[NN_-1][i][j] = Beta[NN_-1][i][j]*inv_Beta_diag[NN_-1][i];
+                Beta[NN_-1][i][j] = Beta[NN_-1][i][j]*Beta[NN_-1][i][i];
             }
 
         }
-    }
-
-    for (unsigned int h=0 ; h < NN_ ; h++){
-
-        for (unsigned int i=0 ; i < nn_ ; i++){
-            Beta[h][i][i] = inv_Beta_diag[h][i]; // We need to make the component-wise inversion of the diagonal elements of Beta
-        }
-        
     }
     // End of computation of Alpha and Beta
 

--- a/types/+laxMPC/code_laxMPC_ADMM_C.c
+++ b/types/+laxMPC/code_laxMPC_ADMM_C.c
@@ -185,11 +185,10 @@ void laxMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
             
             Beta[0][i][j] = BRiBt[i][j];
 
-            if(i>0){
-                for(unsigned int l = 0 ; l <= i-1 ; l++){
-                    Beta[0][i][j] -= Beta[0][l][i]*Beta[0][l][j];
-                }               
-            }
+            for(unsigned int l = 1 ; l <= i ; l++){
+                Beta[0][i][j] -= Beta[0][l-1][i]*Beta[0][l-1][j];
+            }               
+
             if (i==j){
                 Beta[0][i][i] += Q_rho_i[i];
                 Beta[0][i][i] = 1/sqrt(Beta[0][i][i]);
@@ -206,10 +205,8 @@ void laxMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
 
             Alpha[0][i][j] = -Q_rho_i[i]*AB[j][i];
             
-            if(i>0){
-                for(unsigned int l=0 ; l <= i-1 ; l++){
-                    Alpha[0][i][j] -= Beta[0][l][i] * Alpha[0][l][j];
-                }
+            for(unsigned int l=1 ; l <= i ; l++){
+                Alpha[0][i][j] -= Beta[0][l-1][i] * Alpha[0][l-1][j];
             }
 
             Alpha[0][i][j] = Alpha[0][i][j]*Beta[0][i][i];
@@ -229,10 +226,8 @@ void laxMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
                     Beta[h][i][j] -= Alpha[h-1][k][i]*Alpha[h-1][k][j];
                 }
                         
-                if(i>0){
-                    for(unsigned int l = 0 ; l <= i-1 ; l++){
-                        Beta[h][i][j] -= Beta[h][l][i]*Beta[h][l][j];
-                    }
+                for(unsigned int l = 1 ; l <= i ; l++){
+                    Beta[h][i][j] -= Beta[h][l-1][i]*Beta[h][l-1][j];
                 }
                     
                 if(i==j){
@@ -252,10 +247,8 @@ void laxMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
 
                 Alpha[h][i][j] = -Q_rho_i[i]*AB[j][i];
                 
-                if(i>0){
-                    for(unsigned int l=0 ; l <= i-1 ; l++){
-                        Alpha[h][i][j] -= Beta[h][l][i] * Alpha[h][l][j];
-                    }
+                for(unsigned int l=1 ; l <= i ; l++){
+                    Alpha[h][i][j] -= Beta[h][l-1][i] * Alpha[h][l-1][j];
                 }
 
                 Alpha[h][i][j] = Alpha[h][i][j]*Beta[h][i][i];
@@ -276,10 +269,8 @@ void laxMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
                 Beta[NN_-1][i][j] -= Alpha[NN_-2][k][i]*Alpha[NN_-2][k][j];
             }
                         
-            if(i>0){
-                for(unsigned int l = 0 ; l <= i-1 ; l++){
-                    Beta[NN_-1][i][j] -= Beta[NN_-1][l][i]*Beta[NN_-1][l][j];
-                }
+            for(unsigned int l = 1 ; l <= i ; l++){
+                Beta[NN_-1][i][j] -= Beta[NN_-1][l-1][i]*Beta[NN_-1][l-1][j];
             }
 
             Beta[NN_-1][i][j] += T_rho_i[i][j]; // When calculating Beta{N}, as T_rho_i is dense, we add it in every component instead of only in the diagonal as in Beta{0} to Beta{N-2}

--- a/types/+laxMPC/code_laxMPC_ADMM_C.c
+++ b/types/+laxMPC/code_laxMPC_ADMM_C.c
@@ -70,7 +70,7 @@ void laxMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
         double BRiBt[nn_][nn_] = {{0.0}}; // B*inv(R+rho*I)*B'
         double Alpha[NN_-1][nn_][nn_] = {{{0.0}}}; // Variables used for solving the equality constrained QP
         double Beta[NN_][nn_][nn_] = {{{0.0}}}; // Variables used for solving the equality constrained QP
-        double inv_Beta[nn_][nn_] = {{0.0}}; // Inverse of only the current beta is stored
+        double inv_Beta_diag[NN_][nn_] = {{0.0}}; // Diagonal elements of every Beta
         double LB[nm_]; // Lower bound for box constraints 
         double UB[nm_]; // Upper bound for box constraints
     #endif
@@ -194,37 +194,30 @@ void laxMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
             if (i==j){
                 Beta[0][i][j] += Q_rho_i[i];
                 Beta[0][i][j] = sqrt(Beta[0][i][j]);
+                inv_Beta_diag[0][i] = 1/Beta[0][i][i];
             }
             else{ 
-                Beta[0][i][j] = Beta[0][i][j]/Beta[0][i][i];
+                Beta[0][i][j] = Beta[0][i][j]*inv_Beta_diag[0][i];
             }
         }
     }
 
-    // Inverse of Beta{0}
-
-    for (int i=nn_-1 ; i>=0 ; i--){
-        for (unsigned int j=0 ; j<nn_ ; j++){
-            if(i==j){
-                inv_Beta[i][i] = 1/Beta[0][i][i]; // Calculation of diagonal elements
-            }
-            else if (j>i){
-                for(unsigned int k = i+1 ; k<=j ; k++){
-                    inv_Beta[i][j] += Beta[0][i][k]*inv_Beta[k][j];
+    // ALpha{0}
+    for(unsigned int i=0 ; i < nn_ ; i++){
+        for(unsigned int j=0 ; j < nn_ ; j++){
+            Alpha[0][i][j] = -Q_rho_i[i]*AB[j][i];
+            
+            if(i>0){
+                for(unsigned int l=0 ; l <= i-1 ; l++){
+                    Alpha[0][i][j] -= Beta[0][l][i] * Alpha[0][l][j];
                 }
-                inv_Beta[i][j] = -1/Beta[0][i][i]*inv_Beta[i][j];
             }
+
+            Alpha[0][i][j] = Alpha[0][i][j]*inv_Beta_diag[0][i];
+
         }
     }
 
-    // Alpha{0}
-    for (unsigned int i=0 ; i<nn_ ; i++){
-        for (unsigned int j=0 ; j<nn_ ; j++){
-            for (unsigned int k=0 ; k<=i ; k++){
-                Alpha[0][i][j] -= inv_Beta[k][i] * A_in[j+k*nn_] * Q_rho_i[k];
-            }
-        }
-    }
 
     // Beta{1} to Beta{N-2}
     for(unsigned int h = 1; h < NN_-1 ; h++){
@@ -238,7 +231,7 @@ void laxMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
                 }
                         
                 if(i>0){
-                    for(unsigned int l = 0 ; l<=i-1 ; l++){
+                    for(unsigned int l = 0 ; l <= i-1 ; l++){
                         Beta[h][i][j] -= Beta[h][l][i]*Beta[h][l][j];
                     }
                 }
@@ -246,35 +239,27 @@ void laxMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
                 if(i==j){
                     Beta[h][i][j] += Q_rho_i[i];   
                     Beta[h][i][j] = sqrt(Beta[h][i][j]);
+                    inv_Beta_diag[h][i] = 1/Beta[h][i][i];
                 }
                 else {
-                    Beta[h][i][j] = Beta[h][i][j]/Beta[h][i][i];
+                    Beta[h][i][j] = Beta[h][i][j]*inv_Beta_diag[h][i];
                 }
             
             }
         }
-        // Calculation of the inverse of the current Beta, needed for current Alpha
-        memset(inv_Beta, 0, sizeof(inv_Beta)); // Reset of inv_Beta when a new Beta is calculated
-
-        for (int i=nn_-1 ; i>=0 ; i--){
-            for (unsigned int j=0 ; j<nn_ ; j++){
-                if(i==j){
-                    inv_Beta[i][i] = 1/Beta[h][i][i]; // Calculation of diagonal elements
-                }
-                else if (j>i){
-                    for(unsigned int k = i+1 ; k<=j ; k++){
-                        inv_Beta[i][j] += Beta[h][i][k]*inv_Beta[k][j];
+        
+        for(unsigned int i=0 ; i < nn_ ; i++){
+            for(unsigned int j=0 ; j < nn_ ; j++){
+                Alpha[h][i][j] = -Q_rho_i[i]*AB[j][i];
+                
+                if(i>0){
+                    for(unsigned int l=0 ; l <= i-1 ; l++){
+                        Alpha[h][i][j] -= Beta[h][l][i] * Alpha[h][l][j];
                     }
-                    inv_Beta[i][j] = -1/Beta[h][i][i]*inv_Beta[i][j];
                 }
-            }
-        }
 
-        for (unsigned int i=0 ; i<nn_ ; i++){
-            for (unsigned int j=0 ; j<nn_ ; j++){
-                for (unsigned int k=0 ; k<=i ; k++){
-                    Alpha[h][i][j] -= inv_Beta[k][i] * A_in[j+k*nn_] * Q_rho_i[k];
-                }
+                Alpha[h][i][j] = Alpha[h][i][j]*inv_Beta_diag[h][i];
+
             }
         }
 
@@ -292,7 +277,7 @@ void laxMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
             }
                         
             if(i>0){
-                for(unsigned int l = 0 ; l<=i-1 ; l++){
+                for(unsigned int l = 0 ; l <= i-1 ; l++){
                     Beta[NN_-1][i][j] -= Beta[NN_-1][l][i]*Beta[NN_-1][l][j];
                 }
             }
@@ -301,19 +286,20 @@ void laxMPC_ADMM(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int
 
             if(i==j){    
                 Beta[NN_-1][i][j] = sqrt(Beta[NN_-1][i][j]);
+                inv_Beta_diag[NN_-1][i] = 1/Beta[NN_-1][i][i];
             }
 
             else{
-                Beta[NN_-1][i][j] = Beta[NN_-1][i][j]/Beta[NN_-1][i][i];
+                Beta[NN_-1][i][j] = Beta[NN_-1][i][j]*inv_Beta_diag[NN_-1][i];
             }
 
         }
     }
 
-    for (unsigned int h=0 ; h<NN_ ; h++){
+    for (unsigned int h=0 ; h < NN_ ; h++){
 
-        for (unsigned int i=0 ; i<nn_ ; i++){
-            Beta[h][i][i] = 1/Beta[h][i][i]; // We need to make the component-wise inversion of the diagonal elements of Beta
+        for (unsigned int i=0 ; i < nn_ ; i++){
+            Beta[h][i][i] = inv_Beta_diag[h][i]; // We need to make the component-wise inversion of the diagonal elements of Beta
         }
         
     }

--- a/types/+laxMPC/code_laxMPC_FISTA_C.c
+++ b/types/+laxMPC/code_laxMPC_FISTA_C.c
@@ -68,7 +68,7 @@ void laxMPC_FISTA(double *x0_in, double *xr_in, double *ur_in, double *u_opt, in
     double BRiBt[nn_][nn_] = {{0.0}}; // B*inv(R+rho*I)*B'
     double Alpha[NN_-1][nn_][nn_] = {{{0.0}}}; // Variables used for solving the equality constrained QP
     double Beta[NN_][nn_][nn_] = {{{0.0}}}; // Static because they need to go into functions which use their value
-    double inv_Beta[nn_][nn_] = {{0.0}}; // Inverse of only the current beta is stored
+    double inv_Beta_diag[NN_][nn_] = {{0.0}}; // Diagonal elements of every Beta
     double LB[nm_]; // Lower bound for box constraints 
     double UB[nm_]; // Upper bound for box constraints
     #endif
@@ -187,38 +187,31 @@ void laxMPC_FISTA(double *x0_in, double *xr_in, double *ur_in, double *u_opt, in
             if (i==j){
                 Beta[0][i][j] += Q_i[i];
                 Beta[0][i][j] = sqrt(Beta[0][i][j]);
+                inv_Beta_diag[0][i] = 1/Beta[0][i][i];
             }
             else{ 
-                Beta[0][i][j] = Beta[0][i][j]/Beta[0][i][i];
-            }
-        }
-    }
-
-    // Inverse of Beta{0}
-    memset(inv_Beta, 0, sizeof(inv_Beta)); // Reset of inv_Beta when a new Beta is calculated
-    for (int i=nn_-1 ; i>=0 ; i--){
-        for (unsigned int j=0 ; j<nn_ ; j++){
-            if(i==j){
-                inv_Beta[i][i] = 1/Beta[0][i][i]; // Calculation of diagonal elements
-            }
-            else if (j>i){
-                for(unsigned int k = i+1 ; k<=j ; k++){
-                    inv_Beta[i][j] += Beta[0][i][k]*inv_Beta[k][j];
-            }
-                inv_Beta[i][j] = -1/Beta[0][i][i]*inv_Beta[i][j];
-            }
-        }
-    }
-
-    // Alpha{0}
-    for (unsigned int i=0 ; i<nn_ ; i++){
-        for (unsigned int j=0 ; j<nn_ ; j++){
-            for (unsigned int k=0 ; k<=i ; k++){
-                Alpha[0][i][j] -= inv_Beta[k][i] * A_in[j+k*nn_] * Q_i[k];
+                Beta[0][i][j] = Beta[0][i][j]*inv_Beta_diag[0][i];
             }
         }
     }
     
+    // Alpha{0}
+    for (unsigned int i=0 ; i < nn_ ; i++){
+        for (unsigned int j=0 ; j < nn_ ; j++){
+            
+            Alpha[0][i][j] = -Q_i[i]*AB[j][i];
+
+            if(i>0){
+                for(unsigned int l=0 ; l <= i-1 ; l++){
+                    Alpha[0][i][j] -= Beta[0][l][i] * Alpha[0][l][j];
+                }
+            }
+
+            Alpha[0][i][j] = Alpha[0][i][j]*inv_Beta_diag[0][i];
+
+        }
+    }
+
     // Beta{1} to Beta{N-2}
     for(unsigned int h = 1; h < NN_-1 ; h++){
         for(unsigned int i = 0 ; i < nn_ ; i++){
@@ -238,7 +231,8 @@ void laxMPC_FISTA(double *x0_in, double *xr_in, double *ur_in, double *u_opt, in
 
                 if (i==j){        
                     Beta[h][i][j] += Q_i[i];
-                    Beta[h][i][j] = sqrt(Beta[h][i][j]);         
+                    Beta[h][i][j] = sqrt(Beta[h][i][j]);
+                    inv_Beta_diag[h][i] = 1/Beta[h][i][i];         
                 }
 
                 else{
@@ -247,30 +241,25 @@ void laxMPC_FISTA(double *x0_in, double *xr_in, double *ur_in, double *u_opt, in
                     
             }
         }
-        // Calculation of the inverse of the current Beta, needed for current Alpha
-        memset(inv_Beta, 0, sizeof(inv_Beta)); // Reset of inv_Beta when a new Beta is calculated
-        
-        for (int i=nn_-1 ; i>=0 ; i--){
-            for (unsigned int j=0 ; j<nn_ ; j++){
-                if(i==j){
-                    inv_Beta[i][i] = 1/Beta[h][i][i]; // Calculation of diagonal elements
-                }
-                else if (j>i){
-                    for(unsigned int k = i+1 ; k<=j ; k++){
-                        inv_Beta[i][j] += Beta[h][i][k]*inv_Beta[k][j];
+
+        // Alpha[h][][]
+
+        for (unsigned int i=0 ; i < nn_ ; i++){
+            for (unsigned int j=0 ; j < nn_ ; j++){
+                
+                Alpha[h][i][j] = -Q_i[i]*AB[j][i];
+
+                if(i>0){
+                    for(unsigned int l=0 ; l <= i-1 ; l++){
+                        Alpha[h][i][j] -= Beta[h][l][i] * Alpha[h][l][j];
                     }
-                    inv_Beta[i][j] = -1/Beta[h][i][i]*inv_Beta[i][j];
                 }
+
+                Alpha[h][i][j] = Alpha[h][i][j]*inv_Beta_diag[h][i];
+
             }
         }
-        // Calculation of current Alpha
-        for (unsigned int i=0 ; i<nn_ ; i++){
-            for (unsigned int j=0 ; j<nn_ ; j++){
-                for (unsigned int k=0 ; k<=i ; k++){
-                    Alpha[h][i][j] -= inv_Beta[k][i] * A_in[j+k*nn_] * Q_i[k];
-                }
-            }
-        }
+
     }        
 
     //Beta{N-1}
@@ -283,7 +272,7 @@ void laxMPC_FISTA(double *x0_in, double *xr_in, double *ur_in, double *u_opt, in
             }
 
             if(i>0){
-                for(unsigned int l=0 ; l<=i-1 ; l++){
+                for(unsigned int l=0 ; l <= i-1 ; l++){
                     Beta[NN_-1][i][j] -= Beta[NN_-1][l][i] * Beta[NN_-1][l][j];
                 }
             }
@@ -291,20 +280,21 @@ void laxMPC_FISTA(double *x0_in, double *xr_in, double *ur_in, double *u_opt, in
             if(i==j){        
                 Beta[NN_-1][i][j] -= Ti[i]; // Here the sign should be +=, but Ti is multiplied by -1 in the computation of the ingredients                    
                 Beta[NN_-1][i][j] = sqrt(Beta[NN_-1][i][j]);
+                inv_Beta_diag[NN_-1][i] = 1/Beta[NN_-1][i][i];
             }
 
             else{
                 // Here T doesn't apply since we consider it diagonal when using FISTA
-                Beta[NN_-1][i][j] = Beta[NN_-1][i][j]/Beta[NN_-1][i][i];
+                Beta[NN_-1][i][j] = Beta[NN_-1][i][j]*inv_Beta_diag[NN_-1][i];
             }
                             
         }
     }              
 
-    for (unsigned int h=0 ; h<NN_ ; h++){
+    for (unsigned int h=0 ; h < NN_ ; h++){
 
         for (unsigned int i=0 ; i<nn_ ; i++){
-            Beta[h][i][i] = 1/Beta[h][i][i]; // Need to make the component-wise inversion of the diagonal elements of Beta's
+            Beta[h][i][i] = inv_Beta_diag[h][i]; // Need to make the component-wise inversion of the diagonal elements of Beta's
         }
         
     }

--- a/types/+laxMPC/code_laxMPC_FISTA_C.c
+++ b/types/+laxMPC/code_laxMPC_FISTA_C.c
@@ -67,7 +67,7 @@ void laxMPC_FISTA(double *x0_in, double *xr_in, double *ur_in, double *u_opt, in
     double AQiAt[nn_][nn_] = {{0.0}}; // A*inv(Q+rho*I)*A'
     double BRiBt[nn_][nn_] = {{0.0}}; // B*inv(R+rho*I)*B'
     double Alpha[NN_-1][nn_][nn_] = {{{0.0}}}; // Variables used for solving the equality constrained QP
-    double Beta[NN_][nn_][nn_] = {{{0.0}}}; // Static because they need to go into functions which use their value
+    double Beta[NN_][nn_][nn_] = {{{0.0}}}; // Variables used for solving the equality constrained QP. Note: Diagonal of Beta's are inverted
     double LB[nm_]; // Lower bound for box constraints 
     double UB[nm_]; // Upper bound for box constraints
     #endif

--- a/types/+laxMPC/code_laxMPC_FISTA_C.c
+++ b/types/+laxMPC/code_laxMPC_FISTA_C.c
@@ -178,11 +178,10 @@ void laxMPC_FISTA(double *x0_in, double *xr_in, double *ur_in, double *u_opt, in
             
             Beta[0][i][j] = BRiBt[i][j];
 
-            if(i>0){
-                for(unsigned int l = 0 ; l <= i-1 ; l++){
-                    Beta[0][i][j] -= Beta[0][l][i]*Beta[0][l][j];
-                }               
-            }
+            for(unsigned int l = 1 ; l <= i ; l++){
+                Beta[0][i][j] -= Beta[0][l-1][i]*Beta[0][l-1][j];
+            }               
+
             if (i==j){
                 Beta[0][i][i] += Q_i[i];
                 Beta[0][i][i] = 1/sqrt(Beta[0][i][i]);
@@ -199,10 +198,8 @@ void laxMPC_FISTA(double *x0_in, double *xr_in, double *ur_in, double *u_opt, in
             
             Alpha[0][i][j] = -Q_i[i]*AB[j][i];
 
-            if(i>0){
-                for(unsigned int l=0 ; l <= i-1 ; l++){
-                    Alpha[0][i][j] -= Beta[0][l][i] * Alpha[0][l][j];
-                }
+            for(unsigned int l=1 ; l <= i ; l++){
+                Alpha[0][i][j] -= Beta[0][l-1][i] * Alpha[0][l-1][j];
             }
 
             Alpha[0][i][j] = Alpha[0][i][j]*Beta[0][i][i];
@@ -221,11 +218,9 @@ void laxMPC_FISTA(double *x0_in, double *xr_in, double *ur_in, double *u_opt, in
                     Beta[h][i][j] -= Alpha[h-1][k][i]*Alpha[h-1][k][j];
                 }
                         
-                if(i>0){
-                    for(unsigned int l = 0 ; l <= i-1 ; l++){
-                        Beta[h][i][j] -= Beta[h][l][i]*Beta[h][l][j];
-                    }            
-                }
+                for(unsigned int l = 1 ; l <= i ; l++){
+                    Beta[h][i][j] -= Beta[h][l-1][i]*Beta[h][l-1][j];
+                }         
 
                 if (i==j){        
                     Beta[h][i][i] += Q_i[i];
@@ -246,10 +241,8 @@ void laxMPC_FISTA(double *x0_in, double *xr_in, double *ur_in, double *u_opt, in
                 
                 Alpha[h][i][j] = -Q_i[i]*AB[j][i];
 
-                if(i>0){
-                    for(unsigned int l=0 ; l <= i-1 ; l++){
-                        Alpha[h][i][j] -= Beta[h][l][i] * Alpha[h][l][j];
-                    }
+                for(unsigned int l=1 ; l <= i ; l++){
+                    Alpha[h][i][j] -= Beta[h][l-1][i] * Alpha[h][l-1][j];
                 }
 
                 Alpha[h][i][j] = Alpha[h][i][j]*Beta[h][i][i];
@@ -268,10 +261,8 @@ void laxMPC_FISTA(double *x0_in, double *xr_in, double *ur_in, double *u_opt, in
                 Beta[NN_-1][i][j] -= Alpha[NN_-2][k][i]*Alpha[NN_-2][k][j];
             }
 
-            if(i>0){
-                for(unsigned int l=0 ; l <= i-1 ; l++){
-                    Beta[NN_-1][i][j] -= Beta[NN_-1][l][i] * Beta[NN_-1][l][j];
-                }
+            for(unsigned int l=1 ; l <= i ; l++){
+                Beta[NN_-1][i][j] -= Beta[NN_-1][l-1][i] * Beta[NN_-1][l-1][j];
             }
 
             if(i==j){        


### PR DESCRIPTION
The computation of Alpha's is now done without the need of the inverse of Beta. The efficiency is also improved by avoiding some extra variables and conditions checkings.