### PR TITLE
MPCT with soft constraints and constrained outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you use Spcies in your own research, please cite it using the following refer
 
 ```
 @misc{Spcies,
-  author={Krupa, Pablo and Limon, Daniel and Alamo, Teodoro},
+  author={Krupa, Pablo and Gracia, Victor and Limon, Daniel and Alamo, Teodoro},
     title = {{Spcies: Suite of Predictive Controllers for Industrial Embedded Systems}},
     howpublished = {\url{https://github.com/GepocUS/Spcies}},
     month = {Dec},

--- a/examples/t00_basic_tutorial.m
+++ b/examples/t00_basic_tutorial.m
@@ -94,7 +94,7 @@ options.tol = 1e-3; % Exit tolerance of the solver
 % MEX file that will be generated, or the directory where the solver is saved.
 options.save_name = 'mpc_solver';
 options.directory = '';
-options.time = true; % This option tells Spcies to measure the time internally.
+options.timing = true; % This option tells Spcies to measure the time internally.
 
 % If an empty field is provided (as in options.directory = ''), then
 % it is given its default value.

--- a/examples/t01_time_varying_MPC.m
+++ b/examples/t01_time_varying_MPC.m
@@ -40,7 +40,7 @@ options.debug = true; % To get additional information from the solver
 options.time_varying = true; % To select the time-varying solver
 
 options.save_name = 'myMPCsolver';
-options.time = true; % To measure computation times
+options.timing = true; % To measure computation times
 options.formulation = 'equMPC'; % The 'laxMPC' formulation also has time-varying solvers. Check it out!
 % In this tutorial we use the ADMM solver, as selected below, but a time-varying version
 % of the FISTA solver is also available.

--- a/examples/t02_plain_C_solvers.m
+++ b/examples/t02_plain_C_solvers.m
@@ -28,7 +28,7 @@ options.tol = 1e-3; % Exit tolerance of the solver
 
 options.save_name = 'myMPCsolver';
 options.directory = './cl_in_C/'; % We save the solver in the directory were we have the main()
-options.time = true;
+options.timing = true;
 
 % Generate the solver (note that we select the 'platform' as 'C')
 spcies('gen', 'sys', sys, 'param', paramMPC,...

--- a/formulations/+HMPC/struct_HMPC_ADMM_C_Matlab.c
+++ b/formulations/+HMPC/struct_HMPC_ADMM_C_Matlab.c
@@ -15,7 +15,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
     double *u_opt; // Local u_opt
     int k; // Local k
     int e_flag; // Local e_flag
-    sol_$C_CODE_NAME$ sol;
+    sol_$C_CODE_NAME$ sol = {.update_time = 0.0, .solve_time = 0.0, .polish_time = 0.0, .run_time = 0.0};
 
     // Check inputs and outputs
 

--- a/formulations/+HMPC/struct_HMPC_ADMM_split_C_Matlab.c
+++ b/formulations/+HMPC/struct_HMPC_ADMM_split_C_Matlab.c
@@ -15,7 +15,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
     double *u_opt; // Local u_opt
     int k; // Local k
     int e_flag; // Local e_flag
-    sol_$C_CODE_NAME$ sol;
+    sol_$C_CODE_NAME$ sol = {.update_time = 0.0, .solve_time = 0.0, .polish_time = 0.0, .run_time = 0.0};
 
     // Check inputs and outputs
 

--- a/formulations/+HMPC/struct_ellipHMPC_ADMM_C_Matlab.c
+++ b/formulations/+HMPC/struct_ellipHMPC_ADMM_C_Matlab.c
@@ -19,7 +19,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
     double *u_opt; // Local u_opt
     int k; // Local k
     int e_flag; // Local e_flag
-    sol_$C_CODE_NAME$ sol;
+    sol_$C_CODE_NAME$ sol = {.update_time = 0.0, .solve_time = 0.0, .polish_time = 0.0, .run_time = 0.0};
 
     // Check inputs and outputs
 

--- a/formulations/+MPCT/code_MPCT_ADMM_semiband_C.c
+++ b/formulations/+MPCT/code_MPCT_ADMM_semiband_C.c
@@ -902,7 +902,7 @@ void MPCT_ADMM_semiband(double *x0_in, double *xr_in, double *ur_in, double *u_o
             }
 
             // The rest of the vector hard-constrained
-            for (unsigned int l = 1 ; l < NN_+1 ; l++){
+            for (unsigned int l = 1 ; l < NN_ ; l++){
     
                 for (unsigned int i = l*nmp_ ; i < (l+1)*nmp_ ; i++){
                     
@@ -911,6 +911,27 @@ void MPCT_ADMM_semiband(double *x0_in, double *xr_in, double *ur_in, double *u_o
     
                 }
     
+            }
+
+            for (unsigned int i = NN_*nmp_ ; i < NN_*nmp_+nn_ ; i++){
+
+                v[i] = (v[i] > LB[i-NN_*nmp_]+eps_x) ? v[i] : LB[i-NN_*nmp_]+eps_x;
+                v[i] = (v[i] < UB[i-NN_*nmp_]-eps_x) ? v[i] : UB[i-NN_*nmp_]-eps_x;
+
+            }
+
+            for (unsigned int i = NN_*nmp_+nn_ ; i < NN_*nmp_+nm_ ; i++){
+
+                v[i] = (v[i] > LB[i-NN_*nmp_]+eps_u) ? v[i] : LB[i-NN_*nmp_]+eps_u;
+                v[i] = (v[i] < UB[i-NN_*nmp_]-eps_u) ? v[i] : UB[i-NN_*nmp_]-eps_u;
+
+            }
+
+            for (unsigned int i = NN_*nmp_+nm_ ; i < (NN_+1)*nmp_ ; i++){
+
+                v[i] = (v[i] > LB[i-NN_*nmp_]+eps_y) ? v[i] : LB[i-NN_*nmp_]+eps_y;
+                v[i] = (v[i] < UB[i-NN_*nmp_]-eps_y) ? v[i] : UB[i-NN_*nmp_]-eps_y;
+
             }
     
     

--- a/formulations/+MPCT/code_MPCT_ADMM_semiband_C.c
+++ b/formulations/+MPCT/code_MPCT_ADMM_semiband_C.c
@@ -428,7 +428,7 @@ void MPCT_ADMM_semiband(double *x0_in, double *xr_in, double *ur_in, double *u_o
 
             for(unsigned int j = 0 ; j < (NN_+2)*nn_ ; j++){
 
-                z2[i] += M_tilde[i][j] * mu[j]; // z2[i] += M_tilde[i][j] * z1_b[j]. M_tilde is dense, but it presents repetitions inside if rho is scalar, so we use a shortened version of it instead
+                z2[i] += M_tilde[i][j] * mu[j]; // z2[i] += M_tilde[i][j] * z1_b[j]. M_tilde is dense. It does not have repetitions inside when rho is a vector, so we use the full matrix
 
             }
 
@@ -462,7 +462,7 @@ void MPCT_ADMM_semiband(double *x0_in, double *xr_in, double *ur_in, double *u_o
             
                 for (unsigned int j = nn_ ; j < 2*nn_ ; j++){
                 
-                    v[l*nn_+j] += U_tilde[j][i] * z2[i];
+                    v[l*nn_+j] += U_tilde[j][i] * z2[i]; // U_tilde is dense. It does not have repetitions inside when rho is a vector, so we use the full matrix
 
                 }
                 
@@ -1022,8 +1022,6 @@ void MPCT_ADMM_semiband(double *x0_in, double *xr_in, double *ur_in, double *u_o
             done = 1;
             *e_flag = -1;        
         }
-
-        // done = 1; // TODO: Delete this
 
     }
 

--- a/formulations/+MPCT/code_MPCT_ADMM_semiband_C.c
+++ b/formulations/+MPCT/code_MPCT_ADMM_semiband_C.c
@@ -1,7 +1,7 @@
 /**
  * ADMM solver for the MPCT formulation using Woodbury Matrix Identity. Features two different modes:
  * > SOFT_CONSTRAINTS == 0: MPCT formulation with box constraints in states and inputs
- * > SOFT_CONSTRAINTS == 1: MPCT formulation with box constraints in u_0, and "softened" box constraints
+ * > SOFT_CONSTRAINTS == 1: MPCT formulation with hard box constraints in u_0, and "softened" box constraints
  * in the rest of inputs, states, and also in constrained outputs, i.e., y_c = C_c*x_i+D_c*u_i.
  *
  * ARGUMENTS:

--- a/formulations/+MPCT/code_MPCT_ADMM_semiband_C.c
+++ b/formulations/+MPCT/code_MPCT_ADMM_semiband_C.c
@@ -49,7 +49,7 @@ void MPCT_ADMM_semiband(double *x0_in, double *xr_in, double *ur_in, double *u_o
     double lambda[(NN_+1)*nmp_] = {0.0}; // Decision variable lambda
     double C_tilde_z_v[(NN_+1)*nmp_] = {0.0}; // Auxiliary vector for storing C*z-v
     double v_aux1 = 0.0; // Used for computation of v
-    double v_aux2 = 0.0; // Used for computation of v
+    // double v_aux2 = 0.0; // Used for computation of v
     double v_aux3 = 0.0; // Used for computation of v
     #endif
     double q[nm_] = {0.0}; // Linear term vector in the functional. Only non-zero elements are considered.
@@ -847,7 +847,7 @@ void MPCT_ADMM_semiband(double *x0_in, double *xr_in, double *ur_in, double *u_o
         // y_0 soft-constrained
         for (unsigned int i = nm_ ; i<nmp_ ; i++){
             
-            v_aux2 = v[i];
+            // v_aux2 = v[i];
             #ifdef SCALAR_RHO
             v_aux1 = v[i] + beta_rho_i;
             v_aux3 = v[i] - beta_rho_i;
@@ -860,16 +860,16 @@ void MPCT_ADMM_semiband(double *x0_in, double *xr_in, double *ur_in, double *u_o
             if (v_aux1 <= LB[i]){
                 v[i] = v_aux1;
             }
-            else if (v_aux2 >= LB[i] && v_aux2 <= UB[i]){
-                v[i] = v_aux2;
-            }
+            // else if (v_aux2 >= LB[i] && v_aux2 <= UB[i]){
+            //     v[i] = v_aux2;
+            // }
             else if(v_aux3 >= UB[i]){
                 v[i] = v_aux3;
             }
-            else if (v_aux2 > UB[i]){
+            else if (v[i] > UB[i]){ // else if (v_aux2 > UB[i]){
                 v[i] = UB[i];
             }
-            else if (v_aux2 < LB[i]){
+            else if (v[i] < LB[i]){ // else if (v_aux2 < LB[i]){
                 v[i] = LB[i];
             }
 
@@ -880,7 +880,7 @@ void MPCT_ADMM_semiband(double *x0_in, double *xr_in, double *ur_in, double *u_o
 
             for (unsigned int i = l*nmp_ ; i < (l+1)*nmp_ ; i++){
                 
-                v_aux2 = v[i];
+                // v_aux2 = v[i];
                 #ifdef SCALAR_RHO
                 v_aux1 = v[i] + beta_rho_i;
                 v_aux3 = v[i] - beta_rho_i;
@@ -892,16 +892,16 @@ void MPCT_ADMM_semiband(double *x0_in, double *xr_in, double *ur_in, double *u_o
                 if (v_aux1 <= LB[i-l*nmp_]){
                     v[i] = v_aux1;
                 }
-                else if (v_aux2 >= LB[i-l*nmp_] && v_aux2 <= UB[i-l*nmp_]){
-                    v[i] = v_aux2;
-                }
+                // else if (v_aux2 >= LB[i-l*nmp_] && v_aux2 <= UB[i-l*nmp_]){
+                //     v[i] = v_aux2;
+                // }
                 else if(v_aux3 >= UB[i-l*nmp_]){
                     v[i] = v_aux3;
                 }
-                else if (v_aux2 > UB[i-l*nmp_]){
+                else if (v[i] > UB[i-l*nmp_]){ // else if (v_aux2 > UB[i-l*nmp_]){
                     v[i] = UB[i-l*nmp_];
                 }
-                else if (v_aux2 < LB[i-l*nmp_]){
+                else if (v[i] < LB[i-l*nmp_]){ // else if (v_aux2 < LB[i-l*nmp_]){
                     v[i] = LB[i-l*nmp_];
                 }
 

--- a/formulations/+MPCT/code_MPCT_ADMM_semiband_C.c
+++ b/formulations/+MPCT/code_MPCT_ADMM_semiband_C.c
@@ -873,10 +873,7 @@ void MPCT_ADMM_semiband(double *x0_in, double *xr_in, double *ur_in, double *u_o
                 }
     
             }
-    
 
-            #if SOFT_CONSTRAINTS == 0 // CONSTRAINED_OUTPUT == 1 && SOFT_CONSTRAINTS == 0
-            
             // x_0 unconstrained
             for (unsigned int i = 0 ; i < nn_ ; i++){
     
@@ -892,7 +889,10 @@ void MPCT_ADMM_semiband(double *x0_in, double *xr_in, double *ur_in, double *u_o
                 v[i] = (v[i] < UB[i]) ? v[i] : UB[i];
             
             }
+    
 
+            #if SOFT_CONSTRAINTS == 0 // CONSTRAINED_OUTPUT == 1 && SOFT_CONSTRAINTS == 0
+                      
             // y_0 hard-constrained
             for (unsigned int i = nm_ ; i<nmp_ ; i++){
 
@@ -915,22 +915,6 @@ void MPCT_ADMM_semiband(double *x0_in, double *xr_in, double *ur_in, double *u_o
     
     
             #else // CONSTRAINED_OUTPUT == 1 && SOFT_CONSTRAINTS == 1
-    
-            // x_0 unconstrained
-            for (unsigned int i = 0 ; i < nn_ ; i++){
-    
-                v[i] = (v[i] > -inf) ? v[i] : -inf;
-                v[i] = (v[i] < inf) ? v[i] : inf;
-            
-            }
-    
-            // u_0 hard-constrained
-            for (unsigned int i = nn_ ; i < nm_ ; i++){ 
-    
-                v[i] = (v[i] > LB[i]) ? v[i] : LB[i];
-                v[i] = (v[i] < UB[i]) ? v[i] : UB[i];
-    
-            }
     
             // y_0 soft-constrained
             for (unsigned int i = nm_ ; i<nmp_ ; i++){

--- a/formulations/+MPCT/code_MPCT_ADMM_semiband_C.c
+++ b/formulations/+MPCT/code_MPCT_ADMM_semiband_C.c
@@ -983,7 +983,7 @@ void MPCT_ADMM_semiband(double *x0_in, double *xr_in, double *ur_in, double *u_o
             res_fixed_point = (res_fixed_point > 0.0) ? res_fixed_point : -res_fixed_point;
             res_primal_feas = (res_primal_feas > 0.0) ? res_primal_feas : -res_primal_feas;
             
-            if (res_fixed_point > tol || res_primal_feas > tol){
+            if (res_fixed_point > tol_d || res_primal_feas > tol_p){
 
                 res_flag = 1;
                 break;
@@ -1002,7 +1002,7 @@ void MPCT_ADMM_semiband(double *x0_in, double *xr_in, double *ur_in, double *u_o
             res_fixed_point = (res_fixed_point > 0.0) ? res_fixed_point : -res_fixed_point;
             res_primal_feas = (res_primal_feas > 0.0) ? res_primal_feas : -res_primal_feas;
             
-            if (res_fixed_point > tol || res_primal_feas > tol){
+            if (res_fixed_point > tol_d || res_primal_feas > tol_p){
 
                 res_flag = 1;
                 break;

--- a/formulations/+MPCT/code_MPCT_ADMM_semiband_C.c
+++ b/formulations/+MPCT/code_MPCT_ADMM_semiband_C.c
@@ -749,7 +749,7 @@ void MPCT_ADMM_semiband(double *x0_in, double *xr_in, double *ur_in, double *u_o
 
         #if CONSTRAINED_OUTPUT == 0
 
-        for (unsigned int i = 0 ; i < (NN_+1)*nm_ ; i++){
+        for (unsigned int i = 0 ; i < (NN_+1)*nm_ ; i++){ // Computation of v = lambda/rho + z
 
             #ifdef SCALAR_RHO
             v[i] = rho_i * lambda[i] + z[i];

--- a/formulations/+MPCT/compute_MPCT_ADMM_semiband_ingredients.m
+++ b/formulations/+MPCT/compute_MPCT_ADMM_semiband_ingredients.m
@@ -193,11 +193,18 @@ function [vars] = compute_MPCT_ADMM_semiband_ingredients(controller, opt)
     Gamma_tilde_inv = inv(Gamma_tilde); % This avoids the inverse computation online
 
     U_tilde_full = -G*Gamma_hat_inv*U_hat*inv(eye(2*MM)+V_hat*Gamma_hat_inv*U_hat);
-
-    U_tilde = [U_tilde_full(1:2*n,:) ; U_tilde_full(N*n+1:(N+2)*n,:)];
     
+    % If rho is a scalar, some components are repeated inside U_tilde,
+    % otherwise we need the full matrix
+    if vars.rho_is_scalar
+        U_tilde = [U_tilde_full(1:2*n,:) ; U_tilde_full(N*n+1:(N+2)*n,:)];
+    else
+        U_tilde = U_tilde_full;
+    end
+
     V_tilde = V_hat*Gamma_hat_inv*G';
 
+    % M_hat repeats its components independently of rho being a vector
     M_hat = inv((eye(2*(n+m))+V_hat*Gamma_hat_inv*U_hat))*V_hat;
     
     M_hat_x1 = [M_hat(1:n,1:n) ; M_hat(n+m+1:2*n+m,1:n)];
@@ -205,11 +212,18 @@ function [vars] = compute_MPCT_ADMM_semiband_ingredients(controller, opt)
     
     M_hat_u1 = [M_hat(n+1:n+m,n+1:n+m) ; M_hat(2*n+m+1:2*(n+m),n+1:n+m)];
     M_hat_u2 = [M_hat(n+1:n+m, N*(n+m)+n+1:(N+1)*(n+m)) ; M_hat(2*n+m+1:2*(n+m),N*(n+m)+n+1:(N+1)*(n+m))];
+    
 
     M_tilde_full = inv((eye(2*(n+m))+V_tilde*Gamma_tilde_inv*U_tilde_full))*V_tilde;
 
-    M_tilde = [M_tilde_full(:,1:2*n), M_tilde_full(:,N*n+1:(N+2)*n)];
-
+    % If rho is a scalar, some components are repeated inside M_tilde,
+    % otherwise we need the full matrix 
+    if vars.rho_is_scalar
+        M_tilde = [M_tilde_full(:,1:2*n), M_tilde_full(:,N*n+1:(N+2)*n)];
+    else
+        M_tilde = M_tilde_full;
+    end
+    
     % Verification: W = G*inv(H)*G' = Gamma_tilde + U_tilde_full * V_tilde
 
     %% Compute upper and lower bounds

--- a/formulations/+MPCT/compute_MPCT_ADMM_semiband_ingredients.m
+++ b/formulations/+MPCT/compute_MPCT_ADMM_semiband_ingredients.m
@@ -34,7 +34,7 @@ function [vars] = compute_MPCT_ADMM_semiband_ingredients(controller, opt)
         LBu = controller.model.LBu;
         UBx = controller.model.UBx;
         UBu = controller.model.UBu;
-        if opt.solver.soft_constraints
+        if opt.solver.constrained_output
             LBy = controller.model.LBy;
             UBy = controller.model.UBy;
             C = controller.model.C;
@@ -48,7 +48,7 @@ function [vars] = compute_MPCT_ADMM_semiband_ingredients(controller, opt)
         else
             B = controller.sys.B;
         end
-        if opt.solver.soft_constraints
+        if opt.solver.constrained_output
             C = controller.sys.C;
             D = controller.sys.D;
             p = size(C,1);
@@ -80,7 +80,7 @@ function [vars] = compute_MPCT_ADMM_semiband_ingredients(controller, opt)
         catch
             UBu = opt.inf_value*ones(m, 1);
         end
-        if opt.solver.soft_constraints
+        if opt.solver.constrained_output
             try
                 LBy = controller.sys.LBy;
             catch
@@ -96,7 +96,7 @@ function [vars] = compute_MPCT_ADMM_semiband_ingredients(controller, opt)
 
     %% Turn rho into a vector
     if isscalar(opt.solver.rho) && opt.solver.force_vector_rho
-        if ~opt.solver.soft_constraints
+        if ~opt.solver.constrained_output
             rho = opt.solver.rho*ones((N+1)*(n+m), 1);
         else
             rho = opt.solver.rho*ones((N+1)*(n+m+p), 1);
@@ -152,7 +152,7 @@ function [vars] = compute_MPCT_ADMM_semiband_ingredients(controller, opt)
     n_z = size(H,1); % Number of decision variables
 
     %% Compute C_tilde if necessary
-    if opt.solver.soft_constraints == true
+    if opt.solver.constrained_output == true
         C_tilde = [[eye(n) zeros(n,m)];[zeros(m,n) eye(m)];[C D]];
         for i = 2:N+1
             C_tilde = blkdiag(C_tilde , [[eye(n) zeros(n,m)];[zeros(m,n) eye(m)];[C D]]);
@@ -162,13 +162,13 @@ function [vars] = compute_MPCT_ADMM_semiband_ingredients(controller, opt)
     %% Ingredients necessary for low computational complexity
     
     if vars.rho_is_scalar
-        if opt.solver.soft_constraints == true
+        if opt.solver.constrained_output == true
             Gamma_hat = band + rho * (C_tilde'*C_tilde); % Band of P
         else
             Gamma_hat = band + rho * eye(n_z);
         end
     else
-        if opt.solver.soft_constraints == true
+        if opt.solver.constrained_output == true
             Gamma_hat = band + (C_tilde'*diag(rho)*C_tilde);
         else
             Gamma_hat = band + diag(rho);
@@ -229,7 +229,7 @@ function [vars] = compute_MPCT_ADMM_semiband_ingredients(controller, opt)
     %% Compute upper and lower bounds
     LB = [LBx ; LBu];
     UB = [UBx ; UBu];
-    if opt.solver.soft_constraints == true
+    if opt.solver.constrained_output == true
         LB = [LB ; LBy];
         UB = [UB ; UBy];
     end
@@ -238,7 +238,7 @@ function [vars] = compute_MPCT_ADMM_semiband_ingredients(controller, opt)
     vars.N = N;  % Prediction horizon
     vars.n = n; % Dimension of state space
     vars.m = m; % Dimension of input space
-    if opt.solver.soft_constraints == true
+    if opt.solver.constrained_output == true
         vars.p = p; % Dimension of constrained output
     end
     vars.A = A;
@@ -264,7 +264,7 @@ function [vars] = compute_MPCT_ADMM_semiband_ingredients(controller, opt)
     vars.rho = rho;
     if vars.rho_is_scalar
         vars.rho_i = 1/rho;
-        if ~opt.solver.soft_constraints
+        if ~opt.solver.constrained_output
             vars.Q_rho_i = inv(Q + rho*diag(ones(n,1)));
             vars.R_rho_i = inv(R + rho*diag(ones(m,1)));
             vars.S_rho_i = inv(N*R + S + rho*diag(ones(m,1)));
@@ -297,7 +297,7 @@ function [vars] = compute_MPCT_ADMM_semiband_ingredients(controller, opt)
 
     end
 
-    if opt.solver.soft_constraints
+    if opt.solver.constrained_output
         vars.C = C;
         vars.D = D;
         vars.C_tilde = C_tilde; % Just for Matlab version of the solver

--- a/formulations/+MPCT/cons_MPCT_ADMM_semiband_C.m
+++ b/formulations/+MPCT/cons_MPCT_ADMM_semiband_C.m
@@ -24,6 +24,7 @@
 %              - .inf_bound: Scalar. Determines the value given to components without bound.
 %              - .tol: Exit tolerance of the solver.
 %              - .k_max: Maximum number of iterations of the solver.
+%              - .soft_constraints: Determines if soft constraints are allowed as well as constraints of kind LBy <= C*x+D*u <= UBy also softened.
 % 
 % OUTPUTS:
 %   - constructor: An instance of the Spcies_constructor class ready for file generation.
@@ -44,9 +45,19 @@ function constructor = cons_MPCT_ADMM_semiband_C(recipe)
     %% Compute the ingredients of the controller
     vars = MPCT.compute_MPCT_ADMM_semiband_ingredients(recipe.controller, recipe.options);
 
+    % Detect if weight matrices are diagonal
+    if (isdiag(vars.Q) && isdiag(vars.R) && isdiag(vars.T) && isdiag(vars.S))
+        recipe.options.force_diagonal = true; % This option does nothing in this solver for now
+    else
+        recipe.options.force_diagonal = false;
+    end
+
     %% Rename variables for convenience
     n = vars.n;
     m = vars.m;
+    if recipe.options.solver.soft_constraints
+        p = vars.p;
+    end
     N = vars.N;
 
     % Determine if constant variables are defined as static
@@ -63,16 +74,20 @@ function constructor = cons_MPCT_ADMM_semiband_C(recipe)
 
     % Defines
     defCell = recipe.options.default_defCell();
+    defCell = add_line(defCell, 'SOFT_CONSTRAINTS', recipe.options.solver.soft_constraints, 1, 'bool', 'define');
     defCell = add_line(defCell, 'nn_', n, 1, 'uint', 'define');
     defCell = add_line(defCell, 'mm_', m, 1, 'uint', 'define');
     defCell = add_line(defCell, 'nm_', n+m, 1, 'uint', 'define');
+    if recipe.options.solver.soft_constraints
+        defCell = add_line(defCell, 'pp_', p, 1, 'uint', 'define');
+    end
     defCell = add_line(defCell, 'NN_', N, 1, 'uint', 'define');
     defCell = add_line(defCell, 'k_max', recipe.options.solver.k_max, 1, 'uint', 'define');
     defCell = add_line(defCell, 'tol', recipe.options.solver.tol, 1, 'float', 'define');
     defCell = add_line(defCell, 'eps_x', recipe.options.solver.epsilon_x, 1, 'float', 'define');
     defCell = add_line(defCell, 'eps_u', recipe.options.solver.epsilon_u, 1, 'float', 'define');
     defCell = add_line(defCell, 'inf', recipe.options.inf_value, 1, 'float', 'define');
-
+    
     % Constants
     constCell = [];
 
@@ -80,9 +95,15 @@ function constructor = cons_MPCT_ADMM_semiband_C(recipe)
         defCell = add_line(defCell, 'SCALAR_RHO', 1, 0, 'bool', 'define');
         defCell = add_line(defCell, 'rho', vars.rho, 1, precision, 'define');
         defCell = add_line(defCell, 'rho_i', vars.rho_i, 1, precision, 'define');
+        if recipe.options.solver.soft_constraints
+            defCell = add_line(defCell, 'beta_rho_i', vars.beta_rho_i, 1, precision, 'define');
+        end
     else
         constCell = add_line(constCell, 'rho', vars.rho, 1, precision, var_options);
         constCell = add_line(constCell, 'rho_i', vars.rho_i, 1, precision, var_options);
+        if recipe.options.solver.soft_constraints
+            constCell = add_line(constCell, 'beta_rho_i', vars.beta_rho_i, 1, precision, var_options);
+        end
     end
     constCell = add_line(constCell, 'LB', vars.LB, 1, precision, var_options);
     constCell = add_line(constCell, 'UB', vars.UB, 1, precision, var_options);
@@ -96,12 +117,12 @@ function constructor = cons_MPCT_ADMM_semiband_C(recipe)
     constCell = add_line(constCell, 'T_rho_i', vars.T_rho_i, 1, precision, var_options);
     constCell = add_line(constCell, 'A', vars.A, 1, precision, var_options);
     constCell = add_line(constCell, 'B', vars.B, 1, precision, var_options);
+    if recipe.options.solver.soft_constraints
+        constCell = add_line(constCell, 'CD', [vars.C,vars.D], 1, precision, var_options);
+    end
     constCell = add_line(constCell, 'Alpha', vars.Alpha, 1, precision, var_options);
     constCell = add_line(constCell, 'Beta', vars.Beta, 1, precision, var_options);
     constCell = add_line(constCell, 'U_tilde', vars.U_tilde, 1, precision, var_options);
-%     constCell = add_line(constCell, 'M_hat', vars.M_hat, 1, precision, var_options);
-%     constCell = add_line(constCell, 'M_hat_x', vars.M_hat_x, 1, precision, var_options);
-%     constCell = add_line(constCell, 'M_hat_u', vars.M_hat_u, 1, precision, var_options);
     constCell = add_line(constCell, 'M_hat_x1', vars.M_hat_x1, 1, precision, var_options);
     constCell = add_line(constCell, 'M_hat_x2', vars.M_hat_x2, 1, precision, var_options);
     constCell = add_line(constCell, 'M_hat_u1', vars.M_hat_u1, 1, precision, var_options);

--- a/formulations/+MPCT/cons_MPCT_ADMM_semiband_C.m
+++ b/formulations/+MPCT/cons_MPCT_ADMM_semiband_C.m
@@ -124,7 +124,7 @@ function constructor = cons_MPCT_ADMM_semiband_C(recipe)
     if recipe.options.solver.soft_constraints
         var_options_CD = var_options;
         if size(vars.C,1) == 1
-            var_options_CD = [var_options,'matrix'];
+            var_options_CD = [var_options,'matrix']; % TODO: This still neeeds a better solution
         end
         constCell = add_line(constCell, 'CD', [vars.C,vars.D], 1, precision, var_options_CD);
     end

--- a/formulations/+MPCT/cons_MPCT_ADMM_semiband_C.m
+++ b/formulations/+MPCT/cons_MPCT_ADMM_semiband_C.m
@@ -122,7 +122,11 @@ function constructor = cons_MPCT_ADMM_semiband_C(recipe)
     constCell = add_line(constCell, 'A', vars.A, 1, precision, var_options);
     constCell = add_line(constCell, 'B', vars.B, 1, precision, var_options);
     if recipe.options.solver.soft_constraints
-        constCell = add_line(constCell, 'CD', [vars.C,vars.D], 1, precision, var_options);
+        var_options_CD = var_options;
+        if size(vars.C,1) == 1
+            var_options_CD = [var_options,'matrix'];
+        end
+        constCell = add_line(constCell, 'CD', [vars.C,vars.D], 1, precision, var_options_CD);
     end
     constCell = add_line(constCell, 'Alpha', vars.Alpha, 1, precision, var_options);
     constCell = add_line(constCell, 'Beta', vars.Beta, 1, precision, var_options);

--- a/formulations/+MPCT/cons_MPCT_ADMM_semiband_C.m
+++ b/formulations/+MPCT/cons_MPCT_ADMM_semiband_C.m
@@ -80,6 +80,7 @@ function constructor = cons_MPCT_ADMM_semiband_C(recipe)
     defCell = add_line(defCell, 'nm_', n+m, 1, 'uint', 'define');
     if recipe.options.solver.soft_constraints
         defCell = add_line(defCell, 'pp_', p, 1, 'uint', 'define');
+        defCell = add_line(defCell, 'nmp_', n+m+p, 1, 'uint', 'define');
     end
     defCell = add_line(defCell, 'NN_', N, 1, 'uint', 'define');
     defCell = add_line(defCell, 'k_max', recipe.options.solver.k_max, 1, 'uint', 'define');

--- a/formulations/+MPCT/cons_MPCT_ADMM_semiband_C.m
+++ b/formulations/+MPCT/cons_MPCT_ADMM_semiband_C.m
@@ -21,11 +21,12 @@
 %              - .rho: Scalar. Value of the penalty parameter.
 %              - .epsilon_x: Vector by which the bound for x_s are reduced.
 %              - .epsilon_u: Vector by which the bound for u_s are reduced.
+%              - .epsilon_y: Vector by which the bound for C*x_s+D*u_s is reduced.
 %              - .inf_bound: Scalar. Determines the value given to components without bound.
 %              - .tol: Exit tolerance of the solver.
 %              - .k_max: Maximum number of iterations of the solver.
-%              - .soft_constraints: Determines if soft constraints are allowed as well as constraints of kind LBy <= C*x+D*u <= UBy also softened.
-% 
+%              - .soft_constraints: Determines if soft constraints are allowed.
+%              - .constrained_output: Determines if constraints of kind LBy <= C*x+D*u <= UBy are allowed.
 % OUTPUTS:
 %   - constructor: An instance of the Spcies_constructor class ready for file generation.
 %                  
@@ -90,6 +91,9 @@ function constructor = cons_MPCT_ADMM_semiband_C(recipe)
     if ~recipe.options.solver.soft_constraints
         defCell = add_line(defCell, 'eps_x', recipe.options.solver.epsilon_x, 1, 'float', 'define');
         defCell = add_line(defCell, 'eps_u', recipe.options.solver.epsilon_u, 1, 'float', 'define');
+        if recipe.options.solver.constrained_output
+            defCell = add_line(defCell, 'eps_y', recipe.options.solver.epsilon_y, 1, 'float', 'define');
+        end
     end
     defCell = add_line(defCell, 'inf', recipe.options.inf_value, 1, 'float', 'define');
     

--- a/formulations/+MPCT/cons_MPCT_ADMM_semiband_C.m
+++ b/formulations/+MPCT/cons_MPCT_ADMM_semiband_C.m
@@ -55,7 +55,7 @@ function constructor = cons_MPCT_ADMM_semiband_C(recipe)
     %% Rename variables for convenience
     n = vars.n;
     m = vars.m;
-    if recipe.options.solver.soft_constraints
+    if recipe.options.solver.constrained_output
         p = vars.p;
     end
     N = vars.N;
@@ -75,10 +75,11 @@ function constructor = cons_MPCT_ADMM_semiband_C(recipe)
     % Defines
     defCell = recipe.options.default_defCell();
     defCell = add_line(defCell, 'SOFT_CONSTRAINTS', recipe.options.solver.soft_constraints, 1, 'bool', 'define');
+    defCell = add_line(defCell, 'CONSTRAINED_OUTPUT', recipe.options.solver.constrained_output, 1, 'bool', 'define');
     defCell = add_line(defCell, 'nn_', n, 1, 'uint', 'define');
     defCell = add_line(defCell, 'mm_', m, 1, 'uint', 'define');
     defCell = add_line(defCell, 'nm_', n+m, 1, 'uint', 'define');
-    if recipe.options.solver.soft_constraints
+    if recipe.options.solver.constrained_output
         defCell = add_line(defCell, 'pp_', p, 1, 'uint', 'define');
         defCell = add_line(defCell, 'nmp_', n+m+p, 1, 'uint', 'define');
     end
@@ -121,7 +122,7 @@ function constructor = cons_MPCT_ADMM_semiband_C(recipe)
     constCell = add_line(constCell, 'T_rho_i', vars.T_rho_i, 1, precision, var_options);
     constCell = add_line(constCell, 'A', vars.A, 1, precision, var_options);
     constCell = add_line(constCell, 'B', vars.B, 1, precision, var_options);
-    if recipe.options.solver.soft_constraints
+    if recipe.options.solver.constrained_output
         var_options_CD = var_options;
         if size(vars.C,1) == 1
             var_options_CD = [var_options,'matrix']; % TODO: This still neeeds a better solution

--- a/formulations/+MPCT/cons_MPCT_ADMM_semiband_C.m
+++ b/formulations/+MPCT/cons_MPCT_ADMM_semiband_C.m
@@ -84,9 +84,12 @@ function constructor = cons_MPCT_ADMM_semiband_C(recipe)
     end
     defCell = add_line(defCell, 'NN_', N, 1, 'uint', 'define');
     defCell = add_line(defCell, 'k_max', recipe.options.solver.k_max, 1, 'uint', 'define');
-    defCell = add_line(defCell, 'tol', recipe.options.solver.tol, 1, 'float', 'define');
-    defCell = add_line(defCell, 'eps_x', recipe.options.solver.epsilon_x, 1, 'float', 'define');
-    defCell = add_line(defCell, 'eps_u', recipe.options.solver.epsilon_u, 1, 'float', 'define');
+    defCell = add_line(defCell, 'tol_p', recipe.options.solver.tol_p, 1, 'float', 'define');
+    defCell = add_line(defCell, 'tol_d', recipe.options.solver.tol_d, 1, 'float', 'define');
+    if ~recipe.options.solver.soft_constraints
+        defCell = add_line(defCell, 'eps_x', recipe.options.solver.epsilon_x, 1, 'float', 'define');
+        defCell = add_line(defCell, 'eps_u', recipe.options.solver.epsilon_u, 1, 'float', 'define');
+    end
     defCell = add_line(defCell, 'inf', recipe.options.inf_value, 1, 'float', 'define');
     
     % Constants

--- a/formulations/+MPCT/def_options_MPCT_ADMM_semiband.m
+++ b/formulations/+MPCT/def_options_MPCT_ADMM_semiband.m
@@ -21,7 +21,8 @@ function def_options = def_options_MPCT_ADMM_semiband(submethod)
     def_options.tol_d = 1e-4;
     def_options.k_max = 1000;
     def_options.force_vector_rho = false; % If true, forces the penalty parameter rho to be defined as a vector
-    def_options.soft_constraints = false; % If true, contraints of kind LB<= C*x+D*u <= UB are allowed. 
+    def_options.soft_constraints = false; % If true, soft constraints are allowed.
+    def_options.constrained_output = false; % If true, contraints of kind LB<= C*x+D*u <= UB are allowed.
     % Also, every inequality constraint is soft-constrained except for the ones in u_0.
     def_options.beta = 1; % Only useful if soft-constraints are activated
 end

--- a/formulations/+MPCT/def_options_MPCT_ADMM_semiband.m
+++ b/formulations/+MPCT/def_options_MPCT_ADMM_semiband.m
@@ -21,6 +21,8 @@ function def_options = def_options_MPCT_ADMM_semiband(submethod)
     def_options.tol_d = 1e-4;
     def_options.k_max = 1000;
     def_options.force_vector_rho = false; % If true, forces the penalty parameter rho to be defined as a vector
-
+    def_options.soft_constraints = false; % If true, contraints of kind LB<= C*x+D*u <= UB are allowed. 
+    % Also, every inequality constraint is soft-constrained except for the ones in u_0.
+    def_options.beta = 1; % Only useful if soft-constraints are activated
 end
 

--- a/formulations/+MPCT/def_options_MPCT_ADMM_semiband.m
+++ b/formulations/+MPCT/def_options_MPCT_ADMM_semiband.m
@@ -17,13 +17,14 @@ function def_options = def_options_MPCT_ADMM_semiband(submethod)
     def_options.rho = 1e-2;
     def_options.epsilon_x = 1e-6;
     def_options.epsilon_u = 1e-6;
+    def_options.epsilon_y = 1e-6; % Only useful if constrained_output is activated along with hard constraints
     def_options.tol_p = 1e-4;
     def_options.tol_d = 1e-4;
     def_options.k_max = 1000;
     def_options.force_vector_rho = false; % If true, forces the penalty parameter rho to be defined as a vector
     def_options.soft_constraints = false; % If true, soft constraints are allowed.
     def_options.constrained_output = false; % If true, contraints of kind LB<= C*x+D*u <= UB are allowed.
-    % Also, every inequality constraint is soft-constrained except for the ones in u_0.
-    def_options.beta = 1; % Only useful if soft-constraints are activated
+    % Also, every inequality constraint is soft constrained except for the ones in u_0.
+    def_options.beta = 1; % Only useful if soft constraints are activated
 end
 

--- a/formulations/+MPCT/header_MPCT_ADMM_semiband_C.h
+++ b/formulations/+MPCT/header_MPCT_ADMM_semiband_C.h
@@ -13,8 +13,13 @@ $INSERT_DEFINES$
 
 typedef struct {
     double z[(NN_+1)*nm_]; // Optimal z
+    #if SOFT_CONSTRAINTS == 0
     double v[(NN_+1)*nm_]; // Optimal v
     double lambda[(NN_+1)*nm_]; // Optimal lambda
+    #else // SOFT_CONSTRAINTS == 1
+    double v[(NN_+1)*(nm_+pp_)]; // Optimal v
+    double lambda[(NN_+1)*(nm_+pp_)]; // Optimal lambda
+    #endif
     double update_time; // Time taken for the update of the ingredients of the optimization solver
     double solve_time; // Time spent in solving the optimization problem
     double polish_time; // Time taken for extra stuff

--- a/formulations/+MPCT/header_MPCT_ADMM_semiband_C.h
+++ b/formulations/+MPCT/header_MPCT_ADMM_semiband_C.h
@@ -13,10 +13,10 @@ $INSERT_DEFINES$
 
 typedef struct {
     double z[(NN_+1)*nm_]; // Optimal z
-    #if SOFT_CONSTRAINTS == 0
+    #if CONSTRAINED_OUTPUT == 0
     double v[(NN_+1)*nm_]; // Optimal v
     double lambda[(NN_+1)*nm_]; // Optimal lambda
-    #else // SOFT_CONSTRAINTS == 1
+    #else // CONSTRAINED_OUTPUT == 1
     double v[(NN_+1)*(nm_+pp_)]; // Optimal v
     double lambda[(NN_+1)*(nm_+pp_)]; // Optimal lambda
     #endif

--- a/formulations/+MPCT/struct_MPCT_ADMM_cs_C_Matlab.c
+++ b/formulations/+MPCT/struct_MPCT_ADMM_cs_C_Matlab.c
@@ -15,7 +15,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
     double *u_opt; // Local u_opt
     int k; // Local k
     int e_flag; // Local e_flag
-    sol_$C_CODE_NAME$ sol;
+    sol_$C_CODE_NAME$ sol = {.update_time = 0.0, .solve_time = 0.0, .polish_time = 0.0, .run_time = 0.0};
 
     // Check inputs and outputs
 

--- a/formulations/+MPCT/struct_MPCT_ADMM_semiband_C_Matlab.c
+++ b/formulations/+MPCT/struct_MPCT_ADMM_semiband_C_Matlab.c
@@ -71,8 +71,13 @@ void mexFunction(int nlhs, mxArray *plhs[],
     plhs[3] = mxCreateStructMatrix(1, 1, 7, field_names);
 
     z_pt = mxCreateDoubleMatrix((NN_+1)*nm_, 1, mxREAL);
+    #if SOFT_CONSTRAINTS == 0
     v_pt = mxCreateDoubleMatrix((NN_+1)*nm_, 1, mxREAL);
     lambda_pt = mxCreateDoubleMatrix((NN_+1)*nm_, 1, mxREAL);
+    #else
+    v_pt = mxCreateDoubleMatrix((NN_+1)*(nm_+pp_), 1, mxREAL);
+    lambda_pt = mxCreateDoubleMatrix((NN_+1)*(nm_+pp_), 1, mxREAL);
+    #endif
     update_time_pt = mxCreateDoubleMatrix(1, 1, mxREAL);
     solve_time_pt = mxCreateDoubleMatrix(1, 1, mxREAL);
     polish_time_pt = mxCreateDoubleMatrix(1, 1, mxREAL);
@@ -107,11 +112,21 @@ void mexFunction(int nlhs, mxArray *plhs[],
 
     #ifdef DEBUG
 
+    #if SOFT_CONSTRAINTS == 0
     for (unsigned int i = 0 ; i < (NN_+1)*nm_ ; i++) {
         z_out[i] = sol.z[i];
         v_out[i] = sol.v[i];
         lambda_out[i] = sol.lambda[i];
     }
+    #else
+    for (unsigned int i = 0 ; i < (NN_+1)*nm_ ; i++) {
+        z_out[i] = sol.z[i];
+    }
+    for (unsigned int i = 0 ; i < (NN_+1)*(nm_+pp_) ; i++) {
+        v_out[i] = sol.v[i];
+        lambda_out[i] = sol.lambda[i];
+    }
+    #endif
 
     #endif
 

--- a/formulations/+MPCT/struct_MPCT_ADMM_semiband_C_Matlab.c
+++ b/formulations/+MPCT/struct_MPCT_ADMM_semiband_C_Matlab.c
@@ -16,6 +16,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
     int k; // Local k
     int e_flag; // Local e_flag
     sol_$C_CODE_NAME$ sol = {.update_time = 0.0, .solve_time = 0.0, .polish_time = 0.0, .run_time = 0.0};
+    
     // Check inputs and outputs
 
     // Check number of inputs

--- a/formulations/+MPCT/struct_MPCT_ADMM_semiband_C_Matlab.c
+++ b/formulations/+MPCT/struct_MPCT_ADMM_semiband_C_Matlab.c
@@ -15,8 +15,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
     double *u_opt; // Local u_opt
     int k; // Local k
     int e_flag; // Local e_flag
-    sol_$C_CODE_NAME$ sol;
-
+    sol_$C_CODE_NAME$ sol = {.update_time = 0.0, .solve_time = 0.0, .polish_time = 0.0, .run_time = 0.0};
     // Check inputs and outputs
 
     // Check number of inputs

--- a/formulations/+MPCT/struct_MPCT_ADMM_semiband_C_Matlab.c
+++ b/formulations/+MPCT/struct_MPCT_ADMM_semiband_C_Matlab.c
@@ -71,7 +71,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
     plhs[3] = mxCreateStructMatrix(1, 1, 7, field_names);
 
     z_pt = mxCreateDoubleMatrix((NN_+1)*nm_, 1, mxREAL);
-    #if SOFT_CONSTRAINTS == 0
+    #if CONSTRAINED_OUTPUT == 0
     v_pt = mxCreateDoubleMatrix((NN_+1)*nm_, 1, mxREAL);
     lambda_pt = mxCreateDoubleMatrix((NN_+1)*nm_, 1, mxREAL);
     #else
@@ -112,7 +112,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
 
     #ifdef DEBUG
 
-    #if SOFT_CONSTRAINTS == 0
+    #if CONSTRAINED_OUTPUT == 0
     for (unsigned int i = 0 ; i < (NN_+1)*nm_ ; i++) {
         z_out[i] = sol.z[i];
         v_out[i] = sol.v[i];

--- a/formulations/+MPCT/struct_MPCT_EADMM_C_Matlab.c
+++ b/formulations/+MPCT/struct_MPCT_EADMM_C_Matlab.c
@@ -15,7 +15,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
     double *u_opt; // Local u_opt
     int k; // Local k
     int e_flag; // Local e_flag
-    sol_$C_CODE_NAME$ sol;
+    sol_$C_CODE_NAME$ sol = {.update_time = 0.0, .solve_time = 0.0, .polish_time = 0.0, .run_time = 0.0};
 
     // Check inputs and outputs
 

--- a/formulations/+ellipMPC/struct_ellipMPC_ADMM_C_Matlab.c
+++ b/formulations/+ellipMPC/struct_ellipMPC_ADMM_C_Matlab.c
@@ -15,7 +15,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
     double *u_opt; // Local u_opt
     int k; // Local k
     int e_flag; // Local e_flag
-    sol_$C_CODE_NAME$ sol;
+    sol_$C_CODE_NAME$ sol = {.update_time = 0.0, .solve_time = 0.0, .polish_time = 0.0, .run_time = 0.0};
 
     // Check inputs and outputs
 

--- a/formulations/+ellipMPC/struct_ellipMPC_ADMM_soc_C_Matlab.c
+++ b/formulations/+ellipMPC/struct_ellipMPC_ADMM_soc_C_Matlab.c
@@ -16,7 +16,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
     double *u_opt; // Local u_opt
     int k; // Local k
     int e_flag; // Local e_flag
-    sol_$C_CODE_NAME$ sol;
+    sol_$C_CODE_NAME$ sol = {.update_time = 0.0, .solve_time = 0.0, .polish_time = 0.0, .run_time = 0.0};
 
     // Check inputs and outputs
 

--- a/formulations/+equMPC/struct_equMPC_ADMM_C_Matlab.c
+++ b/formulations/+equMPC/struct_equMPC_ADMM_C_Matlab.c
@@ -23,7 +23,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
     double *u_opt; // Local u_opt
     int k; // Local k
     int e_flag; // Local e_flag
-    sol_$C_CODE_NAME$ sol;
+    sol_$C_CODE_NAME$ sol = {.update_time = 0.0, .solve_time = 0.0, .polish_time = 0.0, .run_time = 0.0};
 
     // Check number of inputs
     #if TIME_VARYING == 1

--- a/formulations/+equMPC/struct_equMPC_FISTA_C_Matlab.c
+++ b/formulations/+equMPC/struct_equMPC_FISTA_C_Matlab.c
@@ -23,7 +23,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
     double *u_opt; // Local u_opt
     int k; // Local k
     int e_flag; // Local e_flag
-    sol_$C_CODE_NAME$ sol;
+    sol_$C_CODE_NAME$ sol = {.update_time = 0.0, .solve_time = 0.0, .polish_time = 0.0, .run_time = 0.0};
 
     // Check inputs and outputs
 

--- a/formulations/+laxMPC/struct_laxMPC_ADMM_C_Matlab.c
+++ b/formulations/+laxMPC/struct_laxMPC_ADMM_C_Matlab.c
@@ -23,7 +23,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
     double *u_opt; // Local u_opt
     int k; // Local k
     int e_flag; // Local e_flag
-    sol_$C_CODE_NAME$ sol;
+    sol_$C_CODE_NAME$ sol = {.update_time = 0.0, .solve_time = 0.0, .polish_time = 0.0, .run_time = 0.0};
 
     // Check number of inputs
     #if TIME_VARYING == 1

--- a/formulations/+laxMPC/struct_laxMPC_FISTA_C_Matlab.c
+++ b/formulations/+laxMPC/struct_laxMPC_FISTA_C_Matlab.c
@@ -23,7 +23,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
     double *u_opt; // Local u_opt
     int k; // Local k
     int e_flag; // Local e_flag
-    sol_$C_CODE_NAME$ sol;
+    sol_$C_CODE_NAME$ sol = {.update_time = 0.0, .solve_time = 0.0, .polish_time = 0.0, .run_time = 0.0};
 
     // Check number of inputs
     #if TIME_VARYING == 1

--- a/platforms/+C_code/dec_var.m
+++ b/platforms/+C_code/dec_var.m
@@ -65,6 +65,11 @@ function s = dec_var(var)
     if strcmp(order, 'scalar') && any(strcmp(options, 'array'))
         order = 'vector';
     end
+
+    % Force vector to be declared as matrix if stated splicitly
+    if any(strcmp(options, 'matrix'))
+        order = 'matrix';
+    end
     
     %% Open temporary file for writing the text to
     thefile = fopen([spcies_get_root_directory '/generated_solvers/temp_write_var.txt'], 'wt');

--- a/platforms/+C_code/dec_var.m
+++ b/platforms/+C_code/dec_var.m
@@ -68,7 +68,7 @@ function s = dec_var(var)
 
     % Force vector to be declared as matrix if stated splicitly
     if any(strcmp(options, 'matrix'))
-        order = 'matrix';
+        order = 'matrix'; % TODO: This still needs a better solution
     end
     
     %% Open temporary file for writing the text to

--- a/platforms/Matlab/spcies_MPCT_ADMM_semiband_solver.m
+++ b/platforms/Matlab/spcies_MPCT_ADMM_semiband_solver.m
@@ -440,11 +440,23 @@ function [u, k, e_flag, Hist] = spcies_MPCT_ADMM_semiband_solver(x0, xr, ur, var
                 for i = n+m+1:n+m+pp
                     v(i) = min(max(v(i),var.LB(i)),var.UB(i));
                 end
-
-                for l = 1:N
+                
+                % From x_1 to y_{N-1} 
+                for l = 1:N-1
                     for i = l*(n+m+pp)+1 : (l+1)*(n+m+pp)
                         v(i) = min(max(v(i),var.LB(i-l*(n+m+pp))),var.UB(i-l*(n+m+pp)));
                     end
+                end
+                
+                % From x_s to y_s
+                for i = N*(n+m+pp)+1 : N*(n+m+pp)+n
+                    v(i) = min(max(v(i),var.LB(i-N*(n+m+pp))+options.solver.epsilon_x),var.UB(i-N*(n+m+pp))-options.solver.epsilon_x);
+                end
+                for i = N*(n+m+pp)+n+1 : N*(n+m+pp)+n+m
+                    v(i) = min(max(v(i),var.LB(i-N*(n+m+pp))+options.solver.epsilon_u),var.UB(i-N*(n+m+pp))-options.solver.epsilon_u);
+                end
+                for i = N*(n+m+pp)+n+m+1 : (N+1)*(n+m+pp)
+                    v(i) = min(max(v(i),var.LB(i-N*(n+m+pp))+options.solver.epsilon_y),var.UB(i-N*(n+m+pp))-options.solver.epsilon_y);
                 end
         
             else % options.solver.soft_constraints == true

--- a/platforms/Matlab/spcies_MPCT_ADMM_semiband_solver.m
+++ b/platforms/Matlab/spcies_MPCT_ADMM_semiband_solver.m
@@ -28,8 +28,7 @@
 %          - .A: matrix A of the state space model.
 %          - .B: matrix B of the state space model.
 %          * Only if options.solver.soft_constraints == true *
-%               - .C_c: matrix C_c of the constrained ouput vector y_c =
-%                  C_c*x + D_c*u.
+%               - .C_c: matrix C_c of the constrained output vector y_c = C_c*x + D_c*u.
 %               - .D_c: matrix D_c of the constrained output vector y_c = C_c*x + D_c*u.
 %          It can optionally also contain the following fields:
 %          - .xOptPoint: operating point for the system state.
@@ -55,6 +54,11 @@
 %   - options: Structure containing options of the ADMM_semiband solver.
 %              - .soft_constraints: Boolean to choose if softened box
 %              constraints are considered, as well as softened box constraints in outputs.
+%              - .rho: Penalty parameter of ADMM. Can be either a scalar or
+%                      a vector. Defaults to 1e-2.
+%              * Only if options.solver.soft_constraints == true *
+%                   - .beta: Parameter to weight softened box constraints.
+%                            Can be either a scalar or a vector. Defaults to 1.
 %              - .inf_bound: Scalar. Determines the value given to components without bound.
 %              - .tol_p: Primal exit tolerance of the solver. Defaults to 1e-4.
 %              - .tol_d: Dual exit tolerance (dual) of the solver. Defaults to 1e-4.
@@ -89,6 +93,8 @@
 %
 % This function is part of Spcies: https://github.com/GepocUS/Spcies
 %
+
+% TODO: Change beta from option to necessary input of the solver when options.solver.soft_constraints == true.
 
 function [u, k, e_flag, Hist] = spcies_MPCT_ADMM_semiband_solver(x0, xr, ur, varargin)
     import MPCT.compute_MPCT_ADMM_semiband_ingredients

--- a/platforms/Matlab/spcies_MPCT_ADMM_semiband_solver.m
+++ b/platforms/Matlab/spcies_MPCT_ADMM_semiband_solver.m
@@ -44,7 +44,8 @@
 %              - .epsilon_x: Vector by which the bound for x_s are reduced.
 %              - .epsilon_u: Vector by which the bound for u_s are reduced.
 %              - .inf_bound: Scalar. Determines the value given to components without bound.
-%              - .tol: Exit tolerance of the solver. Defaults to 1e-4.
+%              - .tol_p: Primal exit tolerance of the solver. Defaults to 1e-4.
+%              - .tol_d: Dual exit tolerance (dual) of the solver. Defaults to 1e-4.
 %              - .k_max: Maximum number of iterations of the solver. Defaults to 1000.
 %              - .in_engineering: Boolean that determines if the arguments of the solver are given in
 %                                 engineering units (true) or incremental ones (false - default).
@@ -458,7 +459,7 @@ function [u, k, e_flag, Hist] = spcies_MPCT_ADMM_semiband_solver(x0, xr, ur, var
         r_d = norm(v - v_old,'inf'); % Dual residual
 
         % Check exit condition
-        if (r_p <= options.solver.tol && r_d <= options.solver.tol) % Infinity norm
+        if (r_p <= options.solver.tol_p && r_d <= options.solver.tol_d) % Infinity norm
             done = true;
             e_flag = 1;
         elseif (k >= options.solver.k_max)

--- a/platforms/Matlab/spcies_MPCT_ADMM_semiband_solver.m
+++ b/platforms/Matlab/spcies_MPCT_ADMM_semiband_solver.m
@@ -94,7 +94,7 @@
 % This function is part of Spcies: https://github.com/GepocUS/Spcies
 %
 
-% TODO: Change beta from option to necessary input of the solver when options.solver.soft_constraints == true.
+% TODO: Change beta from option to necessary input of the solver when options.solver.soft_constraints == true and make it deal with beta being a vector.
 
 function [u, k, e_flag, Hist] = spcies_MPCT_ADMM_semiband_solver(x0, xr, ur, varargin)
     import MPCT.compute_MPCT_ADMM_semiband_ingredients


### PR DESCRIPTION
The changes included in this pull request are related to MPC for tracking formulation using ADMM with "semiband" submethod. Specifically, we have:

1. New option named "soft_constraints", which allows us to set soft constraints replacing original hard inequality constraints. We consider every inequality constraint softened except the ones in the input to be applied, i.e., u_0.

2.  New options named "constrained_output", providing the possibility of setting constraints of kind LBy <= C*x <= UBy. Note that, for now, we cannot set D different to 0, as we need to add a new method to solve the cholesky decompositions used in  the semiband structure for this spcific case.

3. Addition of new documentation for this update. Still needs to be improved and reviewed.

Remark: Options "soft_constraints" and "constrained_output" are totally independent of one another. That is, they work for the four possible combinations, setting then either to true or false independently.