### PR TITLE
Adding "initialize_iterates" option to Matlab version of MPCT_ADMM_semiband solver

### DIFF
--- a/formulations/+MPCT/code_MPCT_ADMM_semiband_C.c
+++ b/formulations/+MPCT/code_MPCT_ADMM_semiband_C.c
@@ -19,9 +19,17 @@
  */
 
 #if SOFT_CONSTRAINTS == 1 && ADAPTIVE_BETA == 1
-void MPCT_ADMM_semiband(double *x0_in, double *xr_in, double *ur_in, double *beta_in, double *u_opt, int *k_in, int *e_flag, sol_$INSERT_NAME$ *sol){
+    #ifdef INITIALIZE_ITERATES
+    void MPCT_ADMM_semiband(double *x0_in, double *xr_in, double *ur_in, double *beta_in, double *v_ini_in, double *lambda_ini_in, double *u_opt, int *k_in, int *e_flag, sol_$INSERT_NAME$ *sol){
+    #else
+    void MPCT_ADMM_semiband(double *x0_in, double *xr_in, double *ur_in, double *beta_in, double *u_opt, int *k_in, int *e_flag, sol_$INSERT_NAME$ *sol){
+    #endif
 #else
-void MPCT_ADMM_semiband(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int *k_in, int *e_flag, sol_$INSERT_NAME$ *sol){
+    #ifdef INITIALIZE_ITERATES
+    void MPCT_ADMM_semiband(double *x0_in, double *xr_in, double *ur_in, double *v_ini_in, double *lambda_ini_in, double *u_opt, int *k_in, int *e_flag, sol_$INSERT_NAME$ *sol){
+    #else
+    void MPCT_ADMM_semiband(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int *k_in, int *e_flag, sol_$INSERT_NAME$ *sol){
+    #endif
 #endif
 
     #if MEASURE_TIME == 1
@@ -147,6 +155,19 @@ void MPCT_ADMM_semiband(double *x0_in, double *xr_in, double *ur_in, double *u_o
         #endif
     #endif
 
+    // Get v_ini and lambda_ini if INITIALIZE_ITERATES is defined
+        
+    #ifdef INITIALIZE_ITERATES
+        #if CONSTRAINED_OUTPUT == 0
+        for(unsigned int i = 0; i < (NN_+1)*nm_ ; i++){
+        #else
+        for(unsigned int i = 0; i < (NN_+1)*nmp_ ; i++){
+        #endif
+            v[i] = v_ini_in[i];
+            lambda[i] = lambda_ini_in[i];
+        }
+    #endif
+            
     // Compute q
 
     for(unsigned int i = 0 ; i < nn_ ; i++){
@@ -185,7 +206,7 @@ void MPCT_ADMM_semiband(double *x0_in, double *xr_in, double *ur_in, double *u_o
         memcpy(v_old, v, sizeof(double)*(NN_+1)*nm_);
         #else // CONSTRAINED_OUTPUT == 1
         memcpy(v_old, v, sizeof(double)*(NN_+1)*nmp_);
-        #endif        
+        #endif
         // Reset acumulator variables
         memset(xi, 0, sizeof(double)*(NN_+1)*nm_);
         memset(z3_ac, 0, sizeof(double)*(NN_+1)*nm_);

--- a/formulations/+MPCT/cons_MPCT_ADMM_semiband_C.m
+++ b/formulations/+MPCT/cons_MPCT_ADMM_semiband_C.m
@@ -109,6 +109,9 @@ function constructor = cons_MPCT_ADMM_semiband_C(recipe)
         end
     end
     defCell = add_line(defCell, 'inf', recipe.options.inf_value, 1, 'float', 'define');
+    if recipe.options.solver.initialize_iterates
+        defCell = add_line(defCell, 'INITIALIZE_ITERATES', 1, 0, 'bool', 'define');
+    end
     
     % Constants
     constCell = [];

--- a/formulations/+MPCT/def_options_MPCT_ADMM_semiband.m
+++ b/formulations/+MPCT/def_options_MPCT_ADMM_semiband.m
@@ -30,6 +30,7 @@ function def_options = def_options_MPCT_ADMM_semiband(submethod)
     def_options.tol_d = 1e-4;
     def_options.k_max = 1000;
     def_options.force_vector_rho = false; % If true, forces the penalty parameter rho to be defined as a vector.
+    def_options.initialize_iterates = false; % If true, initial values for v (primal variables) and lambda (dual variables) must be given.
     def_options.soft_constraints = false; % If true, soft constraints are allowed.
     def_options.constrained_output = false; % If true, contraints of kind LB<= C*x+D*u <= UB are allowed.
     % Also, every inequality constraint is soft constrained except for the ones in u_0.
@@ -37,5 +38,6 @@ function def_options = def_options_MPCT_ADMM_semiband(submethod)
     def_options.adaptive_beta = false; % If true, weights for soft constraints can change online.
     def_options.adaptive_beta_is_vector = true; % If true, when adaptive_beta is set to true, the solver requires a vector for beta. If false, the solver requires a scalar.
     def_options.beta = 1; % Only useful if soft constraints are set to true.
+
 end
 

--- a/formulations/+MPCT/header_MPCT_ADMM_semiband_C.h
+++ b/formulations/+MPCT/header_MPCT_ADMM_semiband_C.h
@@ -27,9 +27,17 @@ typedef struct {
 } sol_$INSERT_NAME$;
 
 #if SOFT_CONSTRAINTS == 1 && ADAPTIVE_BETA == 1
-void MPCT_ADMM_semiband(double *x0_in, double *xr_in, double *ur_in, double *beta_in, double *u_opt, int *k_in, int *e_flag, sol_$INSERT_NAME$ *sol);
+    #ifdef INITIALIZE_ITERATES
+    void MPCT_ADMM_semiband(double *x0_in, double *xr_in, double *ur_in, double *beta_in, double *v_ini_in, double *lambda_ini_in, double *u_opt, int *k_in, int *e_flag, sol_$INSERT_NAME$ *sol);
+    #else
+    void MPCT_ADMM_semiband(double *x0_in, double *xr_in, double *ur_in, double *beta_in, double *u_opt, int *k_in, int *e_flag, sol_$INSERT_NAME$ *sol);
+    #endif
 #else
-void MPCT_ADMM_semiband(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int *k_in, int *e_flag, sol_$INSERT_NAME$ *sol);
+    #ifdef INITIALIZE_ITERATES
+    void MPCT_ADMM_semiband(double *x0_in, double *xr_in, double *ur_in, double *v_ini_in, double *lambda_ini_in, double *u_opt, int *k_in, int *e_flag, sol_$INSERT_NAME$ *sol);
+    #else
+    void MPCT_ADMM_semiband(double *x0_in, double *xr_in, double *ur_in, double *u_opt, int *k_in, int *e_flag, sol_$INSERT_NAME$ *sol);
+    #endif
 #endif
 
 #ifdef SCALAR_RHO

--- a/formulations/+MPCT/struct_MPCT_ADMM_semiband_C_Matlab.c
+++ b/formulations/+MPCT/struct_MPCT_ADMM_semiband_C_Matlab.c
@@ -15,6 +15,10 @@ void mexFunction(int nlhs, mxArray *plhs[],
     #if SOFT_CONSTRAINTS == 1 && ADAPTIVE_BETA == 1
     double *beta; // Local beta (soft constraints weights)
     #endif
+    #ifdef INITIALIZE_ITERATES
+    double *v_ini;
+    double *lambda_ini;
+    #endif
     double *u_opt; // Local u_opt
     int k; // Local k
     int e_flag; // Local e_flag
@@ -24,15 +28,29 @@ void mexFunction(int nlhs, mxArray *plhs[],
 
     // Check number of inputs
     #if SOFT_CONSTRAINTS == 1 && ADAPTIVE_BETA == 1
-    if(nrhs != 4){
-        mexErrMsgIdAndTxt("Spcies:MPCT_ADMM:nrhs:number",
-                          "Four inputs are required");
-    }
+        #ifdef INITIALIZE_ITERATES
+            if(nrhs != 6){
+                mexErrMsgIdAndTxt("Spcies:MPCT_ADMM:nrhs:number",
+                                  "Six inputs are required");
+            }
+        #else
+            if(nrhs != 4){
+                mexErrMsgIdAndTxt("Spcies:MPCT_ADMM:nrhs:number",
+                                  "Four inputs are required");
+            }
+        #endif
     #else
-    if(nrhs != 3){
-        mexErrMsgIdAndTxt("Spcies:MPCT_ADMM:nrhs:number",
-                          "Three inputs are required");
-    }
+        #ifdef INITIALIZE_ITERATES
+            if(nrhs != 5){
+                mexErrMsgIdAndTxt("Spcies:MPCT_ADMM:nrhs:number",
+                                  "Five inputs are required");
+            }
+        #else
+            if(nrhs != 3){
+                mexErrMsgIdAndTxt("Spcies:MPCT_ADMM:nrhs:number",
+                                  "Three inputs are required");
+            }
+        #endif
     #endif
 
     // Check number of outputs
@@ -79,6 +97,49 @@ void mexFunction(int nlhs, mxArray *plhs[],
                 }
             #endif
         #endif
+        #ifdef INITIALIZE_ITERATES
+            #if CONSTRAINED_OUTPUT == 0
+                if( !mxIsDouble(prhs[4]) || mxGetNumberOfElements(prhs[4]) != (NN_+1)*nm_){
+                    mexErrMsgIdAndTxt("Spcies:MPCT_ADMM_semiband:nrhs:v_ini",
+                                      "v_ini must be a vector of dimension %%d", (NN_+1)*nm_);
+                }
+                if( !mxIsDouble(prhs[5]) || mxGetNumberOfElements(prhs[5]) != (NN_+1)*nm_){
+                    mexErrMsgIdAndTxt("Spcies:MPCT_ADMM_semiband:nrhs:lambda_ini",
+                                      "lambda_ini must be a vector of dimension %%d", (NN_+1)*nm_);
+                }
+            #else
+                if( !mxIsDouble(prhs[4]) || mxGetNumberOfElements(prhs[4]) != (NN_+1)*(nm_+pp_)){
+                    mexErrMsgIdAndTxt("Spcies:MPCT_ADMM_semiband:nrhs:v_ini",
+                                      "v_ini must be a vector of dimension %%d", (NN_+1)*(nm_+pp_));
+                }
+                if( !mxIsDouble(prhs[5]) || mxGetNumberOfElements(prhs[5]) != (NN_+1)*(nm_+pp_)){
+                    mexErrMsgIdAndTxt("Spcies:MPCT_ADMM_semiband:nrhs:lambda_ini",
+                                      "lambda_ini must be a vector of dimension %%d", (NN_+1)*(nm_+pp_));
+                }
+            #endif
+        #endif
+    #else
+        #ifdef INITIALIZE_ITERATES
+            #if CONSTRAINED_OUTPUT == 0
+                if( !mxIsDouble(prhs[3]) || mxGetNumberOfElements(prhs[3]) != (NN_+1)*nm_){
+                    mexErrMsgIdAndTxt("Spcies:MPCT_ADMM_semiband:nrhs:v_ini",
+                                      "v_ini must be a vector of dimension %%d", (NN_+1)*nm_);
+                }
+                if( !mxIsDouble(prhs[4]) || mxGetNumberOfElements(prhs[4]) != (NN_+1)*nm_){
+                    mexErrMsgIdAndTxt("Spcies:MPCT_ADMM_semiband:nrhs:lambda_ini",
+                                      "lambda_ini must be a vector of dimension %%d", (NN_+1)*nm_);
+                }
+            #else
+                if( !mxIsDouble(prhs[3]) || mxGetNumberOfElements(prhs[3]) != (NN_+1)*(nm_+pp_)){
+                    mexErrMsgIdAndTxt("Spcies:MPCT_ADMM_semiband:nrhs:v_ini",
+                                      "v_ini must be a vector of dimension %%d", (NN_+1)*(nm_+pp_));
+                }
+                if( !mxIsDouble(prhs[4]) || mxGetNumberOfElements(prhs[4]) != (NN_+1)*(nm_+pp_)){
+                    mexErrMsgIdAndTxt("Spcies:MPCT_ADMM_semiband:nrhs:lambda_ini",
+                                      "lambda_ini must be a vector of dimension %%d", (NN_+1)*(nm_+pp_));
+                }
+            #endif
+        #endif
     #endif
 
     // Read input data
@@ -87,7 +148,17 @@ void mexFunction(int nlhs, mxArray *plhs[],
     ur = (double*) mxGetData(prhs[2]);
     #if SOFT_CONSTRAINTS == 1 && ADAPTIVE_BETA == 1
     beta = (double*) mxGetData(prhs[3]);
+        #ifdef INITIALIZE_ITERATES
+        v_ini = (double*) mxGetData(prhs[4]);
+        lambda_ini = (double*) mxGetData(prhs[5]);
+        #endif
+    #else
+        #ifdef INITIALIZE_ITERATES
+        v_ini = (double*) mxGetData(prhs[3]);
+        lambda_ini = (double*) mxGetData(prhs[4]);
+        #endif
     #endif
+    
 
     // Prepare output data
     mxArray *z_pt, *v_pt, *lambda_pt, *update_time_pt, *solve_time_pt, *polish_time_pt, *run_time_pt;
@@ -136,9 +207,17 @@ void mexFunction(int nlhs, mxArray *plhs[],
 
     // Call solver
     #if SOFT_CONSTRAINTS == 1 && ADAPTIVE_BETA == 1
-    MPCT_ADMM_semiband(x0, xr, ur, beta, u_opt, &k, &e_flag, &sol);
+        #ifdef INITIALIZE_ITERATES
+        MPCT_ADMM_semiband(x0, xr, ur, beta, v_ini, lambda_ini, u_opt, &k, &e_flag, &sol);
+        #else
+        MPCT_ADMM_semiband(x0, xr, ur, beta, u_opt, &k, &e_flag, &sol);
+        #endif
     #else
-    MPCT_ADMM_semiband(x0, xr, ur, u_opt, &k, &e_flag, &sol);
+        #ifdef INITIALIZE_ITERATES
+        MPCT_ADMM_semiband(x0, xr, ur, v_ini, lambda_ini, u_opt, &k, &e_flag, &sol);
+        #else
+        MPCT_ADMM_semiband(x0, xr, ur, u_opt, &k, &e_flag, &sol);
+        #endif
     #endif
 
     // Set output values

--- a/platforms/Matlab/spcies_MPCT_ADMM_semiband_solver.m
+++ b/platforms/Matlab/spcies_MPCT_ADMM_semiband_solver.m
@@ -80,7 +80,6 @@
 %              - .in_engineering: Boolean that determines if the arguments of the solver are given in
 %                                 engineering units (true) or incremental ones (false - default).
 %              - .initialize_iterates: Boolean that determines if initial values for v (primal variables) and lambda (dual variables) must be given.
-%              initial value for 
 %              * Only if options.solver.soft_constraints == false *
 %                   - .epsilon_x: Vector by which the bound for x_s are reduced when there are no soft constraints.
 %                   - .epsilon_u: Vector by which the bound for u_s are reduced when there are no soft constraints.
@@ -166,7 +165,6 @@ function [u, k, e_flag, Hist] = spcies_MPCT_ADMM_semiband_solver(x0, xr, ur, var
     verbose = par.Results.verbose;
     if verbose > 3; verbose = 3; end
     if verbose < 0; verbose = 0; end
-    
     
     %% Generate ingredients of the solver
     var = compute_MPCT_ADMM_semiband_ingredients(controller, options);

--- a/platforms/Matlab/spcies_MPCT_ADMM_semiband_solver.m
+++ b/platforms/Matlab/spcies_MPCT_ADMM_semiband_solver.m
@@ -79,6 +79,8 @@
 %              - .k_max: Maximum number of iterations of the solver. Defaults to 1000.
 %              - .in_engineering: Boolean that determines if the arguments of the solver are given in
 %                                 engineering units (true) or incremental ones (false - default).
+%              - .initialize_iterates: Boolean that determines if initial values for v (primal variables) and lambda (dual variables) must be given.
+%              initial value for 
 %              * Only if options.solver.soft_constraints == false *
 %                   - .epsilon_x: Vector by which the bound for x_s are reduced when there are no soft constraints.
 %                   - .epsilon_u: Vector by which the bound for u_s are reduced when there are no soft constraints.
@@ -108,8 +110,6 @@
 % This function is part of Spcies: https://github.com/GepocUS/Spcies
 %
 
-% TODO: Change beta from option to necessary input of the solver when options.solver.soft_constraints == true and make it deal with beta being a vector.
-
 function [u, k, e_flag, Hist] = spcies_MPCT_ADMM_semiband_solver(x0, xr, ur, varargin)
     import MPCT.compute_MPCT_ADMM_semiband_ingredients
 
@@ -133,6 +133,9 @@ function [u, k, e_flag, Hist] = spcies_MPCT_ADMM_semiband_solver(x0, xr, ur, var
     addParameter(par, 'options', def_options, @(x) isstruct(x));
     addParameter(par, 'genHist', def_genHist, @(x) isnumeric(x) && (x>=0));
     addParameter(par, 'verbose', def_verbose, @(x) isnumeric(x) && (x>=0));
+    % New inputs for warm-start
+    addParameter(par, 'v_ini', []);
+    addParameter(par, 'lambda_ini', []);
 
     % Parse
     parse(par, varargin{:})
@@ -164,6 +167,7 @@ function [u, k, e_flag, Hist] = spcies_MPCT_ADMM_semiband_solver(x0, xr, ur, var
     if verbose > 3; verbose = 3; end
     if verbose < 0; verbose = 0; end
     
+    
     %% Generate ingredients of the solver
     var = compute_MPCT_ADMM_semiband_ingredients(controller, options);
     N = var.N;
@@ -180,13 +184,49 @@ function [u, k, e_flag, Hist] = spcies_MPCT_ADMM_semiband_solver(x0, xr, ur, var
     k = 0;
     z = zeros((N+1)*(n+m),1);
     if ~options.solver.constrained_output
-        v = zeros((N+1)*(n+m),1);
-        v_old = zeros((N+1)*(n+m),1); % Value of v in the previous iteration
-        lambda = zeros((N+1)*(n+m),1);
+        if options.solver.initialize_iterates
+            if ~isempty(par.Results.v_ini)
+                v = par.Results.v_ini;
+                if size(v,1) ~= (N+1)*(n+m)
+                    error("v_ini must be a column vector of dimension %d", (N+1)*(n+m));
+                end
+            else
+                v = zeros((N+1)*(n+m),1);
+            end
+            if ~isempty(par.Results.lambda_ini)
+                lambda = par.Results.lambda_ini;
+                if size(lambda,1) ~= (N+1)*(n+m)
+                    error("lambda_ini must be a column vector of dimension %d", (N+1)*(n+m));
+                end
+            else
+                lambda = zeros((N+1)*(n+m+pp),1);
+            end
+        else
+            v = zeros((N+1)*(n+m),1);
+            lambda = zeros((N+1)*(n+m),1);
+        end
     else
-        v = zeros((N+1)*(n+m+pp),1);
-        v_old = zeros((N+1)*(n+m+pp),1); % Value of v in the previous iteration
-        lambda = zeros((N+1)*(n+m+pp),1);
+        if options.solver.initialize_iterates
+            if ~isempty(par.Results.v_ini)
+                v = par.Results.v_ini;
+                if size(v,1) ~= (N+1)*(n+m+pp)
+                    error("v_ini must be a column vector of dimension %d", (N+1)*(n+m+pp));
+                end
+            else
+                v = zeros((N+1)*(n+m+pp),1);
+            end
+            if ~isempty(par.Results.lambda_ini)
+                lambda = par.Results.lambda_ini;
+                if size(lambda,1) ~= (N+1)*(n+m+pp)
+                    error("lambda_ini must be a column vector of dimension %d", (N+1)*(n+m+pp));
+                end
+            else
+                lambda = zeros((N+1)*(n+m+pp),1);
+            end
+        else
+            v = zeros((N+1)*(n+m+pp),1);
+            lambda = zeros((N+1)*(n+m+pp),1);
+        end
     end
 
     % Historics
@@ -234,6 +274,9 @@ function [u, k, e_flag, Hist] = spcies_MPCT_ADMM_semiband_solver(x0, xr, ur, var
 
     while ~done
         k = k + 1;
+
+        % Save value of v in the previous iteration
+        v_old = v;
 
         % Equality constrained QP solve : Update z
 
@@ -576,9 +619,7 @@ function [u, k, e_flag, Hist] = spcies_MPCT_ADMM_semiband_solver(x0, xr, ur, var
             e_flag = -1;
         end
 
-        % Update variables and historics
-        v_old = v;
-
+        % Update historics
         if genHist > 0
             hRp(k) = r_p;
             hRd(k) = r_d;


### PR DESCRIPTION
Initial iterates (for warmstart) can be passed as inputs (using parser) to the Matlab version of the MPCT_ADMM_semiband solver.

There was a small conflict that I resolved.

 The solvers in both C and Matlab versions were tested and work correctly.